### PR TITLE
ECNIM-457

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -74,7 +74,8 @@
           "./packages/react/Title",
           "./packages/react/Toast",
           "./packages/react/Button",
-          "./packages/react/Tooltip"
+          "./packages/react/Tooltip",
+          "./packages/react/Stack"
         ]
       }
     ],

--- a/.yarn/versions/11bbf1d4.yml
+++ b/.yarn/versions/11bbf1d4.yml
@@ -1,0 +1,26 @@
+releases:
+  "@nimbus-ds/popover": patch
+  "@nimbus-ds/stack": major
+  "@nimbus-ds/styles": minor
+  "@nimbus-ds/tooltip": patch
+
+declined:
+  - nimbus-design-system
+  - "@nimbus-ds/badge"
+  - "@nimbus-ds/box"
+  - "@nimbus-ds/button"
+  - "@nimbus-ds/checkbox"
+  - "@nimbus-ds/chip"
+  - "@nimbus-ds/icon"
+  - "@nimbus-ds/icon-button"
+  - "@nimbus-ds/label"
+  - "@nimbus-ds/link"
+  - "@nimbus-ds/list"
+  - "@nimbus-ds/radio"
+  - "@nimbus-ds/skeleton"
+  - "@nimbus-ds/spinner"
+  - "@nimbus-ds/tag"
+  - "@nimbus-ds/text"
+  - "@nimbus-ds/title"
+  - "@nimbus-ds/toast"
+  - "@nimbus-ds/toggle"

--- a/packages/react/Popover/CHANGELOG.md
+++ b/packages/react/Popover/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Use Popovers to bring attention to specific user interface elements and suggest an action or to guide users through a new experience
 
+## 2022-10-14
+
+### 🎉 New features
+
+- Added box-shadow to popover arrow. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+- Added styles so that the popover container has a maximum width relative to the anchor size. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2022-10-06
 
 ### 📚 3rd party library updates

--- a/packages/react/Popover/package.json
+++ b/packages/react/Popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/popover",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -41,5 +41,6 @@
     "typescript": "^4.7.4",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
-  }
+  },
+  "stableVersion": "1.0.0"
 }

--- a/packages/react/Popover/package.json
+++ b/packages/react/Popover/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/TiendaNube/nimbus-design-system/issues"
   },
   "devDependencies": {
+    "@nimbus-ds/stack": "workspace:*",
     "@vanilla-extract/dynamic": "^2.0.2",
     "terser-webpack-plugin": "^5.3.5",
     "ts-loader": "^9.3.1",

--- a/packages/react/Popover/src/Popover.tsx
+++ b/packages/react/Popover/src/Popover.tsx
@@ -38,7 +38,7 @@ const Popover: React.FC<PopoverProps> = ({
     open: isVisible,
     placement: position,
     strategy: "fixed",
-    middleware: [offset(8), arrowUI({ element: arrowRef })],
+    middleware: [offset(10), arrowUI({ element: arrowRef })],
     onOpenChange: setVisibility,
   });
 
@@ -56,6 +56,7 @@ const Popover: React.FC<PopoverProps> = ({
       <div
         data-testid="popover-container"
         ref={reference}
+        className={popover.style.container}
         {...getReferenceProps()}
       >
         {children}
@@ -68,7 +69,6 @@ const Popover: React.FC<PopoverProps> = ({
             className={[
               popover.style.content,
               popover.sprinkle({
-                color: appearance,
                 backgroundColor: appearance,
                 padding,
               }),
@@ -85,7 +85,12 @@ const Popover: React.FC<PopoverProps> = ({
               <div
                 data-testid="arrow-element"
                 ref={arrowRef}
-                className={popover.style.arrow[position]}
+                className={[
+                  popover.style.arrow[position],
+                  popover.sprinkle({
+                    color: appearance,
+                  }),
+                ].join(" ")}
                 style={{
                   position: "absolute",
                   left: arrowX != null ? `${arrowX}px` : "",

--- a/packages/react/Popover/src/popover.spec.tsx
+++ b/packages/react/Popover/src/popover.spec.tsx
@@ -40,7 +40,7 @@ describe("GIVEN <Popover />", () => {
       const arrow = screen.getByTestId("arrow-element");
       expect(popover).toBeDefined();
 
-      expect(popover.style.top).toEqual("-8px");
+      expect(popover.style.top).toEqual("-10px");
       expect(popover.style.left).toEqual("0px");
       expect(popover.style.position).toEqual("fixed");
 
@@ -58,7 +58,7 @@ describe("GIVEN <Popover />", () => {
       const arrow = screen.getByTestId("arrow-element");
       expect(popover).toBeDefined();
 
-      expect(popover.style.top).toEqual("8px");
+      expect(popover.style.top).toEqual("10px");
       expect(popover.style.left).toEqual("0px");
       expect(popover.style.position).toEqual("fixed");
 
@@ -77,7 +77,7 @@ describe("GIVEN <Popover />", () => {
       expect(popover).toBeDefined();
 
       expect(popover.style.top).toEqual("0px");
-      expect(popover.style.left).toEqual("-8px");
+      expect(popover.style.left).toEqual("-10px");
       expect(popover.style.position).toEqual("fixed");
 
       expect(arrow.style.top).toEqual("0px");
@@ -95,7 +95,7 @@ describe("GIVEN <Popover />", () => {
       expect(popover).toBeDefined();
 
       expect(popover.style.top).toEqual("0px");
-      expect(popover.style.left).toEqual("8px");
+      expect(popover.style.left).toEqual("10px");
       expect(popover.style.position).toEqual("fixed");
 
       expect(arrow.style.top).toEqual("0px");

--- a/packages/react/Popover/src/popover.stories.tsx
+++ b/packages/react/Popover/src/popover.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { withA11y } from "@storybook/addon-a11y";
 import { Text } from "@nimbus-ds/text";
+import { Stack } from "@nimbus-ds/stack";
 
 import { Popover } from "./Popover";
 
@@ -18,11 +19,11 @@ export default {
 } as ComponentMeta<typeof Popover>;
 
 const Template: ComponentStory<typeof Popover> = (args) => (
-  <div style={{ display: "flex", justifyContent: "center" }}>
+  <Stack display="flex" justifyContent="center">
     <Popover {...args}>
       <Text>Hover</Text>
     </Popover>
-  </div>
+  </Stack>
 );
 
 export const base = Template.bind({});

--- a/packages/react/Stack/CHANGELOG.md
+++ b/packages/react/Stack/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+A low-level utility component that accepts styled system props to enable custom theme-aware styling
+
+## 2022-10-14
+
+### 📚 3rd party library updates
+
+- Added `@vanilla-extract/dynamic@2.0.2`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `@vanilla-extract/webpack-plugin@2.1.11`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `terser-webpack-plugin@5.3.5`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `ts-loader@9.3.1`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `typescript@4.7.4`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `webpack@5.74.0`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `webpack-cli@4.10.0`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+
+### 🎉 New features
+
+- Added `width`, `height`, `flex`, `borderWidth`, `gridTemplateAreas`, `gridTemplateColumns`, `gridTemplateRows`, `gap`, `gridGap`, `display`, `flexDirection`, `flexWrap`, `justifyContent` and `alignItems` properties to the Component. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+- Added stories on Component. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))

--- a/packages/react/Stack/README.md
+++ b/packages/react/Stack/README.md
@@ -1,0 +1,15 @@
+# `@nimbus-ds/stack`
+
+[![@nimbus-ds/stack](https://img.shields.io/npm/v/@nimbus-ds/stack?label=%40nimbus-ds%2Fstack)](https://www.npmjs.com/package/@nimbus-ds/stack)
+
+## Installation
+
+```sh
+$ yarn add @nimbus-ds/stack
+# or
+$ npm install @nimbus-ds/stack
+```
+
+## Usage
+
+View docs [here](https://nimbus.nuvemshop.com.br/documentation/atomic-components/stack).

--- a/packages/react/Stack/package.json
+++ b/packages/react/Stack/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@nimbus-ds/stack",
+  "version": "0.0.0",
+  "license": "MIT",
+  "source": "src/index.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.module.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "yarn build:types && webpack",
+    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir ./dist --baseUrl ../../../",
+    "clean": "rm -rf dist",
+    "version": "yarn version"
+  },
+  "dependencies": {
+    "@nimbus-ds/styles": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  },
+  "homepage": "https://nimbus.nuvemshop.com.br/documentation",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TiendaNube/nimbus-design-system.git"
+  },
+  "bugs": {
+    "url": "https://github.com/TiendaNube/nimbus-design-system/issues"
+  },
+  "devDependencies": {
+    "@nimbus-ds/box": "workspace:*",
+    "@vanilla-extract/dynamic": "^2.0.2",
+    "terser-webpack-plugin": "^5.3.5",
+    "ts-loader": "^9.3.1",
+    "typescript": "^4.7.4",
+    "webpack": "^5.74.0",
+    "webpack-cli": "^4.10.0"
+  }
+}

--- a/packages/react/Stack/package.json
+++ b/packages/react/Stack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/stack",
-  "version": "0.0.0",
+  "version": "1.0.0-rc.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -40,5 +40,6 @@
     "typescript": "^4.7.4",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
-  }
+  },
+  "stableVersion": "0.0.0"
 }

--- a/packages/react/Stack/src/Stack.tsx
+++ b/packages/react/Stack/src/Stack.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { stack } from "@nimbus-ds/styles";
+
+import { StackProps } from "./stack.types";
+
+const Stack: React.FC<StackProps> = ({
+  className: _className,
+  style: _style,
+  children,
+  ...rest
+}) => {
+  const { className, style, otherProps } = stack.sprinkle(rest);
+  return (
+    <div className={className} style={style} {...otherProps}>
+      {children}
+    </div>
+  );
+};
+
+Stack.displayName = "Stack";
+export { Stack };

--- a/packages/react/Stack/src/index.ts
+++ b/packages/react/Stack/src/index.ts
@@ -1,0 +1,6 @@
+import { Stack } from "./Stack";
+import "@nimbus-ds/styles/packages/stack/index.css";
+
+export { Stack } from "./Stack";
+export type { StackProps } from "./stack.types";
+export default Stack;

--- a/packages/react/Stack/src/stack.spec.tsx
+++ b/packages/react/Stack/src/stack.spec.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { Stack } from "./Stack";
+import { StackProps } from "./stack.types";
+
+const makeSut = (props: StackProps) => {
+  render(<Stack {...props} data-testid="stack-element" />);
+};
+
+describe("GIVEN <Stack />", () => {
+  describe("WHEN rendered", () => {
+    it("THEN should render default responsive styles", () => {
+      makeSut({
+        height: "10rem",
+        width: "50rem",
+      });
+      const stack = screen.getByTestId("stack-element");
+      expect(stack.getAttribute("style")).toMatch(
+        /--width-xs__\w{0,9}: 50rem;/
+      );
+      expect(stack.getAttribute("style")).toMatch(
+        /--height-xs__\w{0,9}: 10rem;/
+      );
+    });
+
+    it("THEN should render responsive styles correctly", () => {
+      makeSut({
+        display: { lg: "flex", md: "grid", xs: "block" },
+      });
+      const stack = screen.getByTestId("stack-element");
+      expect(stack.getAttribute("class")).toContain("block-xs");
+      expect(stack.getAttribute("class")).toMatch("grid-md");
+      expect(stack.getAttribute("class")).toMatch("flex-lg");
+    });
+  });
+});

--- a/packages/react/Stack/src/stack.stories.tsx
+++ b/packages/react/Stack/src/stack.stories.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { withA11y } from "@storybook/addon-a11y";
+import { stack } from "@nimbus-ds/styles";
+import { Box } from "@nimbus-ds/box";
+
+import { Stack } from "./Stack";
+
+export default {
+  title: "Atomic/Stack",
+  component: Stack,
+  argTypes: {
+    children: { control: { disable: true } },
+    flex: { type: "string" },
+    gridTemplateAreas: { type: "string" },
+    gridTemplateColumns: { type: "string" },
+    gridTemplateRows: { type: "string" },
+    display: { options: stack.properties.display },
+    flexDirection: { options: stack.properties.flexDirection },
+    flexWrap: { options: stack.properties.flexWrap },
+    justifyContent: { options: stack.properties.justifyContent },
+    alignItems: { options: stack.properties.alignItems },
+    gridGap: { options: Object.keys(stack.properties.gridGap) },
+    gap: { options: Object.keys(stack.properties.gap) },
+  },
+  parameters: {
+    withA11y: { decorators: [withA11y] },
+  },
+} as ComponentMeta<typeof Stack>;
+
+const Template: ComponentStory<typeof Stack> = (args) => <Stack {...args} />;
+
+export const base = Template.bind({});
+base.args = {
+  display: "flex",
+  justifyContent: "center",
+  flexDirection: "row",
+  gap: "2",
+  children: (
+    <>
+      <Box
+        width="3rem"
+        height="2rem"
+        borderStyle="solid"
+        borderRadius="4px"
+        borderWidth="1px"
+        borderColor="neutral.interactive"
+      />
+      <Box
+        width="3rem"
+        height="2rem"
+        borderStyle="solid"
+        borderRadius="4px"
+        borderWidth="1px"
+        borderColor="neutral.interactive"
+      />
+    </>
+  ),
+};
+
+export const responsive = Template.bind({});
+responsive.args = {
+  display: "flex",
+  gap: "2",
+  flexDirection: {
+    lg: "row",
+    md: "column",
+  },
+  justifyContent: {
+    lg: "center",
+    md: "flex-end",
+  },
+  children: (
+    <>
+      <Box
+        width="3rem"
+        height="2rem"
+        borderStyle="solid"
+        borderRadius="4px"
+        borderWidth="1px"
+        borderColor="neutral.interactive"
+      />
+      <Box
+        width="3rem"
+        height="2rem"
+        borderStyle="solid"
+        borderRadius="4px"
+        borderWidth="1px"
+        borderColor="neutral.interactive"
+      />
+    </>
+  ),
+};
+
+export const flex = Template.bind({});
+flex.args = {
+  display: "flex",
+  gap: "2",
+  flexDirection: "row",
+  justifyContent: "center",
+  children: (
+    <>
+      <Box
+        width="100%"
+        height="2rem"
+        borderStyle="solid"
+        borderRadius="4px"
+        borderWidth="1px"
+        borderColor="neutral.interactive"
+      />
+      <Box
+        width="50%"
+        height="2rem"
+        borderStyle="solid"
+        borderRadius="4px"
+        borderWidth="1px"
+        borderColor="neutral.interactive"
+      />
+    </>
+  ),
+};
+
+export const grid = Template.bind({});
+grid.args = {
+  display: "grid",
+  gap: "2",
+  gridTemplateColumns: "1fr 1fr 1fr",
+  gridTemplateRows: "1fr",
+  height: "8rem",
+  children: (
+    <>
+      <Box
+        borderStyle="solid"
+        borderRadius="4px"
+        borderWidth="1px"
+        borderColor="neutral.interactive"
+      />
+      <Box
+        borderStyle="solid"
+        borderRadius="4px"
+        borderWidth="1px"
+        borderColor="neutral.interactive"
+      />
+      <Box
+        borderStyle="solid"
+        borderRadius="4px"
+        borderWidth="1px"
+        borderColor="neutral.interactive"
+      />
+    </>
+  ),
+};

--- a/packages/react/Stack/src/stack.types.ts
+++ b/packages/react/Stack/src/stack.types.ts
@@ -1,0 +1,11 @@
+import { HTMLAttributes, ReactNode } from "react";
+import { stack } from "@nimbus-ds/styles";
+
+export type StackSprinkle = Parameters<typeof stack.sprinkle>[0];
+
+type Extends = StackSprinkle & HTMLAttributes<HTMLDivElement>;
+
+export interface StackProps extends Extends {
+  /** Element to be rendered inside the Stack component */
+  children?: ReactNode;
+}

--- a/packages/react/Stack/tsconfig.json
+++ b/packages/react/Stack/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declaration": false,
+    "paths": {
+      "@nimbus-ds/styles": ["../../styles/src"]
+    }
+  }
+}

--- a/packages/react/Stack/webpack.config.js
+++ b/packages/react/Stack/webpack.config.js
@@ -1,0 +1,46 @@
+const path = require("path");
+const { VanillaExtractPlugin } = require("@vanilla-extract/webpack-plugin");
+const TerserJSPlugin = require("terser-webpack-plugin");
+
+module.exports = {
+  mode: "development",
+  devtool: "source-map",
+  entry: {
+    "./index": "./src/index.ts",
+  },
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: "[name].js",
+    libraryTarget: "umd",
+    library: "@nimbus-ds/stack",
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: "ts-loader",
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.css$/i,
+        use: ["style-loader", "css-loader"],
+      },
+    ],
+  },
+  plugins: [new VanillaExtractPlugin()],
+  resolve: {
+    alias: {
+      "@nimbus-ds/styles": path.resolve(__dirname, "../../styles/dist"),
+    },
+    extensions: [".tsx", ".ts", ".js"],
+  },
+  optimization: {
+    minimize: true,
+    minimizer: [new TerserJSPlugin()],
+  },
+  externals: {
+    "@nimbus-ds/styles": "@nimbus-ds/styles",
+    react: "react",
+    "react-dom": "react-dom",
+  },
+};

--- a/packages/react/Tooltip/CHANGELOG.md
+++ b/packages/react/Tooltip/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The Tooltip component allows us to display additional information in a non-intrusive way.
 
+## 2022-10-14
+
+### 🎉 New features
+
+- Added styles so that the tooltip container has a maximum width relative to the anchor size. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2022-10-06
 
 ### 💡 Others

--- a/packages/react/Tooltip/package.json
+++ b/packages/react/Tooltip/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/TiendaNube/nimbus-design-system/issues"
   },
   "devDependencies": {
+    "@nimbus-ds/stack": "workspace:*",
     "@vanilla-extract/dynamic": "^2.0.2",
     "terser-webpack-plugin": "^5.3.5",
     "ts-loader": "^9.3.1",

--- a/packages/react/Tooltip/package.json
+++ b/packages/react/Tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/tooltip",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -41,5 +41,6 @@
     "typescript": "^4.7.4",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
-  }
+  },
+  "stableVersion": "1.0.1"
 }

--- a/packages/react/Tooltip/src/Tooltip.tsx
+++ b/packages/react/Tooltip/src/Tooltip.tsx
@@ -54,6 +54,7 @@ const Tooltip: React.FC<TooltipProps> = ({
       <div
         data-testid="tooltip-container"
         ref={reference}
+        className={tooltip.style.container}
         {...getReferenceProps()}
       >
         {children}

--- a/packages/react/Tooltip/src/tooltip.stories.tsx
+++ b/packages/react/Tooltip/src/tooltip.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { withA11y } from "@storybook/addon-a11y";
 import { Text } from "@nimbus-ds/text";
+import { Stack } from "@nimbus-ds/stack";
 
 import { Tooltip } from "./Tooltip";
 
@@ -17,11 +18,11 @@ export default {
 } as ComponentMeta<typeof Tooltip>;
 
 const Template: ComponentStory<typeof Tooltip> = (args) => (
-  <div style={{ display: "flex", justifyContent: "center" }}>
+  <Stack display="flex" justifyContent="center">
     <Tooltip {...args}>
       <Text>Hover</Text>
     </Tooltip>
-  </div>
+  </Stack>
 );
 
 export const base = Template.bind({});

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -7,10 +7,10 @@ Nimbus Styles deprive all styles needed to build nimbus components.
 ### 🎉 New features
 
 - Added new style pack for stack component. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+- Added box-shadow to popover arrow. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
 
 ### 💡 Others
 
-- Adding box-shadow to popover arrow. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
 - Added styles so that the popover container has a maximum width relative to its anchor size. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
 - Added styles so that the tooltip container has a maximum width relative to its anchor size. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
 

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Nimbus Styles deprive all styles needed to build nimbus components.
 
+## 2022-10-14
+
+### 🎉 New features
+
+- Added new style pack for stack component. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+
+### 💡 Others
+
+- Adding box-shadow to popover arrow. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+- Added styles so that the popover container has a maximum width relative to its anchor size. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+- Added styles so that the tooltip container has a maximum width relative to its anchor size. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2022-10-11
 
 ### 🎉 New features

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/styles",
-  "version": "4.6.0",
+  "version": "4.7.0-rc.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -38,5 +38,6 @@
     "ts-loader": "^9.3.1",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
-  }
+  },
+  "stableVersion": "4.6.0"
 }

--- a/packages/styles/src/index.ts
+++ b/packages/styles/src/index.ts
@@ -10,6 +10,7 @@ export { iconButton } from "./packages/iconButton";
 export { label } from "./packages/label";
 export { skeleton } from "./packages/skeleton";
 export { spinner } from "./packages/spinner";
+export { stack } from "./packages/stack";
 export { tag } from "./packages/tag";
 export { text } from "./packages/text";
 export { title } from "./packages/title";

--- a/packages/styles/src/packages/popover/popover.style.css.ts
+++ b/packages/styles/src/packages/popover/popover.style.css.ts
@@ -2,14 +2,17 @@ import { style, styleVariants } from "@vanilla-extract/css";
 
 import { varsThemeBase } from "../../themes/base.css";
 
+export const container = style({
+  width: "fit-content",
+});
+
 export const content = style({
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
   width: "17.5rem",
   minHeight: "2rem",
-
-  boxShadow: varsThemeBase.shadow.popover,
+  filter: `drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.2))`,
   borderRadius: varsThemeBase.spacing[2],
   boxSizing: "border-box",
   transition: `opacity ${varsThemeBase.motion.speed.fast} ease`,

--- a/packages/styles/src/packages/stack/index.ts
+++ b/packages/styles/src/packages/stack/index.ts
@@ -1,0 +1,22 @@
+import {
+  sprinkle,
+  displayProperties,
+  flexDirectionProperties,
+  flexWrapProperties,
+  justifyContentProperties,
+  alignItemsProperties,
+  spaceProperties,
+} from "./stack.sprinkle.css";
+
+export const stack = {
+  sprinkle,
+  properties: {
+    display: displayProperties,
+    flexDirection: flexDirectionProperties,
+    flexWrap: flexWrapProperties,
+    justifyContent: justifyContentProperties,
+    alignItems: alignItemsProperties,
+    gap: spaceProperties,
+    gridGap: spaceProperties,
+  },
+};

--- a/packages/styles/src/packages/stack/stack.sprinkle.css.ts
+++ b/packages/styles/src/packages/stack/stack.sprinkle.css.ts
@@ -1,0 +1,94 @@
+import { createRainbowSprinkles, defineProperties } from "rainbow-sprinkles";
+import { varsThemeBase } from "../../themes/base.css";
+import { mediaQueries } from "../../themes/mediaQueries";
+
+type FlexWrap = "nowrap" | "wrap" | "wrap-reverse";
+type FlexDirection = "row" | "row-reverse" | "column" | "column-reverse";
+
+export const displayProperties = [
+  "block",
+  "flex",
+  "inline-flex",
+  "grid",
+  "inline-grid",
+];
+export const flexDirectionProperties: FlexDirection[] = [
+  "row",
+  "row-reverse",
+  "column",
+  "column-reverse",
+];
+
+export const flexWrapProperties: FlexWrap[] = [
+  "nowrap",
+  "wrap",
+  "wrap-reverse",
+];
+
+export const justifyContentProperties = [
+  "flex-start",
+  "flex-end",
+  "center",
+  "space-between",
+  "space-around",
+  "space-evenly",
+];
+
+export const alignItemsProperties = [
+  "stretch",
+  "flex-start",
+  "flex-end",
+  "center",
+  "baseline",
+];
+
+export const spaceProperties = {
+  none: "0",
+  "0,5": varsThemeBase.spacing["0,5"],
+  "1": varsThemeBase.spacing[1],
+  "2": varsThemeBase.spacing[2],
+  "4": varsThemeBase.spacing[4],
+  "6": varsThemeBase.spacing[6],
+  "8": varsThemeBase.spacing[8],
+  "10": varsThemeBase.spacing[10],
+  "12": varsThemeBase.spacing[12],
+  "14": varsThemeBase.spacing[14],
+  "16": varsThemeBase.spacing[16],
+  "18": varsThemeBase.spacing[18],
+  "20": varsThemeBase.spacing[20],
+};
+
+const properties = defineProperties({
+  conditions: {
+    xs: {
+      "@media": mediaQueries.xs(),
+    },
+    md: {
+      "@media": mediaQueries.md(),
+    },
+    lg: {
+      "@media": mediaQueries.lg(),
+    },
+  },
+  defaultCondition: "xs",
+  dynamicProperties: {
+    width: true,
+    height: true,
+    flex: true,
+    gridTemplateAreas: true,
+    gridTemplateColumns: true,
+    gridTemplateRows: true,
+    gap: spaceProperties,
+    gridGap: spaceProperties,
+  },
+  staticProperties: {
+    display: displayProperties,
+    flexDirection: flexDirectionProperties,
+    flexWrap: flexWrapProperties,
+    justifyContent: justifyContentProperties,
+    alignItems: alignItemsProperties,
+  },
+  shorthands: {},
+});
+
+export const sprinkle = createRainbowSprinkles(properties);

--- a/packages/styles/src/packages/toast/toast.style.css.ts
+++ b/packages/styles/src/packages/toast/toast.style.css.ts
@@ -1,9 +1,6 @@
 import { style as vanillaStyle, styleVariants } from "@vanilla-extract/css";
-import tokens from "@nimbus-ds/tokens/dist/js/tokens";
 
 import { varsThemeBase } from "../../themes/base.css";
-
-const { spacing } = tokens;
 
 const base = vanillaStyle({
   display: "flex",
@@ -14,12 +11,12 @@ const base = vanillaStyle({
   height: "2rem",
   width: "fit-content",
 
-  padding: spacing["1"].value,
+  padding: varsThemeBase.spacing[1],
   boxSizing: "border-box",
 
   borderWidth: "0.063rem",
   borderStyle: "solid",
-  borderRadius: spacing["1"].value,
+  borderRadius: varsThemeBase.spacing[1],
 
   transition: `${varsThemeBase.motion.speed.fast} ease`,
 });

--- a/packages/styles/src/packages/tooltip/tooltip.style.css.ts
+++ b/packages/styles/src/packages/tooltip/tooltip.style.css.ts
@@ -2,6 +2,10 @@ import { style, styleVariants } from "@vanilla-extract/css";
 
 import { varsThemeBase } from "../../themes/base.css";
 
+export const container = style({
+  width: "fit-content",
+});
+
 export const content = style({
   width: "fit-content",
   backgroundColor: varsThemeBase.colors.neutral.textLow,

--- a/packages/styles/src/themes/base.css.ts
+++ b/packages/styles/src/themes/base.css.ts
@@ -294,9 +294,6 @@ createGlobalTheme(":root", varsThemeBase, {
     },
   },
   breakpoint: {
-    // xs: `screen and (min-width: ${breakpoint.xs.value})`,
-    // md: `screen and (min-width: ${breakpoint.md.value})`,
-    // lg: `screen and (min-width: ${breakpoint.lg.value})`,
     xs: breakpoint.xs.value,
     md: breakpoint.md.value,
     lg: breakpoint.lg.value,

--- a/packages/styles/webpack.config.js
+++ b/packages/styles/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
     "./packages/label/index": "./src/packages/label/index",
     "./packages/skeleton/index": "./src/packages/skeleton/index",
     "./packages/spinner/index": "./src/packages/spinner/index",
+    "./packages/stack/index": "./src/packages/stack/index",
     "./packages/tag/index": "./src/packages/tag/index",
     "./packages/text/index": "./src/packages/text/index",
     "./packages/title/index": "./src/packages/title/index",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3018,6 +3018,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@nimbus-ds/stack@workspace:packages/react/Stack":
+  version: 0.0.0-use.local
+  resolution: "@nimbus-ds/stack@workspace:packages/react/Stack"
+  dependencies:
+    "@nimbus-ds/styles": "workspace:*"
+    "@vanilla-extract/dynamic": ^2.0.2
+    terser-webpack-plugin: ^5.3.5
+    ts-loader: ^9.3.1
+    typescript: ^4.7.4
+    webpack: ^5.74.0
+    webpack-cli: ^4.10.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  languageName: unknown
+  linkType: soft
+
 "@nimbus-ds/styles@workspace:*, @nimbus-ds/styles@workspace:packages/styles":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/styles@workspace:packages/styles"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2780,7 +2780,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/box@workspace:packages/react/Box":
+"@nimbus-ds/box@workspace:*, @nimbus-ds/box@workspace:packages/react/Box":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/box@workspace:packages/react/Box"
   dependencies:
@@ -2952,6 +2952,7 @@ __metadata:
   resolution: "@nimbus-ds/popover@workspace:packages/react/Popover"
   dependencies:
     "@floating-ui/react-dom-interactions": ^0.10.1
+    "@nimbus-ds/stack": "workspace:*"
     "@nimbus-ds/styles": "workspace:*"
     "@vanilla-extract/dynamic": ^2.0.2
     terser-webpack-plugin: ^5.3.5
@@ -3018,10 +3019,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/stack@workspace:packages/react/Stack":
+"@nimbus-ds/stack@workspace:*, @nimbus-ds/stack@workspace:packages/react/Stack":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/stack@workspace:packages/react/Stack"
   dependencies:
+    "@nimbus-ds/box": "workspace:*"
     "@nimbus-ds/styles": "workspace:*"
     "@vanilla-extract/dynamic": ^2.0.2
     terser-webpack-plugin: ^5.3.5
@@ -3157,6 +3159,7 @@ __metadata:
   resolution: "@nimbus-ds/tooltip@workspace:packages/react/Tooltip"
   dependencies:
     "@floating-ui/react-dom-interactions": ^0.10.1
+    "@nimbus-ds/stack": "workspace:*"
     "@nimbus-ds/styles": "workspace:*"
     "@vanilla-extract/dynamic": ^2.0.2
     terser-webpack-plugin: ^5.3.5


### PR DESCRIPTION
# ECNIM-457

## Type

- [ ] Bugfix 🐛
- [x] New feature 🌈
- [ ] Change request 🤓
- [x] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

- `@nimbus-ds/stack`

  ### 📚 3rd party library updates

  - Added `@vanilla-extract/dynamic@2.0.2`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
  - Added `@vanilla-extract/webpack-plugin@2.1.11`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
  - Added `terser-webpack-plugin@5.3.5`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
  - Added `ts-loader@9.3.1`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
  - Added `typescript@4.7.4`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
  - Added `webpack@5.74.0`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
  - Added `webpack-cli@4.10.0`. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))

  ### 🎉 New features

  - Added `width`, `height`, `flex`, `borderWidth`, `gridTemplateAreas`, `gridTemplateColumns`, `gridTemplateRows`, `gap`, `gridGap`, `display`, `flexDirection`, `flexWrap`, `justifyContent` and `alignItems` properties to the Component. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
  - Added stories on Component. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
    <br/>

- `@nimbus-ds/styles`

  ### 🎉 New features

  - Added new style pack for stack component. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
  - Added box-shadow to popover arrow. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))

  ### 💡 Others

  - Added styles so that the popover container has a maximum width relative to its anchor size. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
  - Added styles so that the tooltip container has a maximum width relative to its anchor size. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
    <br/>

- `@nimbus-ds/popover`

  ### 🎉 New features

  - Added box-shadow to popover arrow. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
  - Added styles so that the popover container has a maximum width relative to the anchor size. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))
    <br/>

- `@nimbus-ds/tooltip`

  ### 🎉 New features

  - Added styles so that the tooltip container has a maximum width relative to the anchor size. ([#40](https://github.com/TiendaNube/nimbus-design-system/pull/40) by [@juniorconquista](https://github.com/juniorconquista))

## Screenshots 🏞

## Related issues 🐛
