### PR TITLE
ECNIM-532

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -68,6 +68,7 @@
           "./packages/styles",
           "./packages/tokens",
           "./packages/react/Skeleton",
+          "./packages/react/Sidebar",
           "./packages/react/Chip",
           "./packages/react/Tag",
           "./packages/react/Text",

--- a/.yarn/versions/585e9915.yml
+++ b/.yarn/versions/585e9915.yml
@@ -1,0 +1,34 @@
+releases:
+  "@nimbus-ds/alert": patch
+  "@nimbus-ds/box": patch
+  "@nimbus-ds/sidebar": major
+  "@nimbus-ds/styles": minor
+
+declined:
+  - nimbus-design-system
+  - "@nimbus-ds/badge"
+  - "@nimbus-ds/button"
+  - "@nimbus-ds/card"
+  - "@nimbus-ds/checkbox"
+  - "@nimbus-ds/chip"
+  - "@nimbus-ds/file-uploader"
+  - "@nimbus-ds/icon"
+  - "@nimbus-ds/icon-button"
+  - "@nimbus-ds/input"
+  - "@nimbus-ds/label"
+  - "@nimbus-ds/link"
+  - "@nimbus-ds/list"
+  - "@nimbus-ds/popover"
+  - "@nimbus-ds/radio"
+  - "@nimbus-ds/select"
+  - "@nimbus-ds/skeleton"
+  - "@nimbus-ds/spinner"
+  - "@nimbus-ds/stack"
+  - "@nimbus-ds/tag"
+  - "@nimbus-ds/text"
+  - "@nimbus-ds/textarea"
+  - "@nimbus-ds/thumbnail"
+  - "@nimbus-ds/title"
+  - "@nimbus-ds/toast"
+  - "@nimbus-ds/toggle"
+  - "@nimbus-ds/tooltip"

--- a/.yarn/versions/585e9915.yml
+++ b/.yarn/versions/585e9915.yml
@@ -1,6 +1,7 @@
 releases:
   "@nimbus-ds/alert": patch
   "@nimbus-ds/box": patch
+  "@nimbus-ds/icon-button": patch
   "@nimbus-ds/sidebar": major
   "@nimbus-ds/styles": minor
 
@@ -13,7 +14,6 @@ declined:
   - "@nimbus-ds/chip"
   - "@nimbus-ds/file-uploader"
   - "@nimbus-ds/icon"
-  - "@nimbus-ds/icon-button"
   - "@nimbus-ds/input"
   - "@nimbus-ds/label"
   - "@nimbus-ds/link"

--- a/packages/react/Alert/CHANGELOG.md
+++ b/packages/react/Alert/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The alert component is used to showcase relevant or time-sensitive information to the user in a visually prominent banner.
 
-## 2022-10-26
+## 2022-11-16 `1.0.1`
+
+### 🐛 Bug fixes
+
+- Externalizing component build style pack. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/#56) by [@juniorconquista](https://github.com/juniorconquista))
+
+## 2022-10-26 `1.0.0`
 
 ### 📚 3rd party library updates
 

--- a/packages/react/Alert/package.json
+++ b/packages/react/Alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/alert",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -42,5 +42,6 @@
     "typescript": "^4.7.4",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
-  }
+  },
+  "stableVersion": "1.0.0"
 }

--- a/packages/react/Alert/webpack.config.js
+++ b/packages/react/Alert/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = {
     "@nimbus-ds/skeleton": "@nimbus-ds/skeleton",
     "@nimbus-ds/title": "@nimbus-ds/title",
     "@nimbus-ds/icon": "@nimbus-ds/icon",
+    "@nimbus-ds/styles": "@nimbus-ds/styles",
     react: "react",
     "react-dom": "react-dom",
   },

--- a/packages/react/Box/CHANGELOG.md
+++ b/packages/react/Box/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 A low-level utility component that accepts styled system props to enable custom theme-aware styling
 
+## 2022-11-16 `1.0.2`
+
+### 🐛 Bug fixes
+
+- Added `box-sizing` to component styling. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/#56) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2022-11-09 `1.0.1`
 
 ### 🐛 Bug fixes

--- a/packages/react/Box/package.json
+++ b/packages/react/Box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/box",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -39,5 +39,6 @@
     "typescript": "^4.7.4",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
-  }
+  },
+  "stableVersion": "1.0.1"
 }

--- a/packages/react/Box/src/Box.tsx
+++ b/packages/react/Box/src/Box.tsx
@@ -11,7 +11,11 @@ const Box: React.FC<BoxProps> = ({
 }) => {
   const { className, style, otherProps } = box.sprinkle(rest);
   return (
-    <div className={className} style={style} {...otherProps}>
+    <div
+      className={[className, box.style.container].join(" ")}
+      style={style}
+      {...otherProps}
+    >
       {children}
     </div>
   );

--- a/packages/react/IconButton/CHANGELOG.md
+++ b/packages/react/IconButton/CHANGELOG.md
@@ -6,7 +6,7 @@ Icons are used to visually communicate core parts of the product and available a
 
 ### 🐛 Bug fixes
 
-- Updating internal version of @nimbus-ds/icon package. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
+- Updating internal version of `@nimbus-ds/icon` package. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
 
 ## 2022-09-27 `1.0.0`
 

--- a/packages/react/IconButton/CHANGELOG.md
+++ b/packages/react/IconButton/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Icons are used to visually communicate core parts of the product and available actions. They can act as wayfinding tools to help merchants more easily understand where they are in the product, and common interaction patterns that are available..
 
-## 2022-09-27
+## 2022-11-16 `1.0.1`
+
+### 🐛 Bug fixes
+
+- Updating internal version of @nimbus-ds/icon package. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
+
+## 2022-09-27 `1.0.0`
 
 ### 📚 3rd party library updates
 

--- a/packages/react/IconButton/package.json
+++ b/packages/react/IconButton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/icon-button",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -41,5 +41,6 @@
     "typescript": "^4.7.4",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
-  }
+  },
+  "stableVersion": "1.0.0"
 }

--- a/packages/react/Sidebar/CHANGELOG.md
+++ b/packages/react/Sidebar/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+Sidebars navigation provides access to the parts within its application. The side sections have the supplementary content that is linked on the left or right side of the screen.
+
+## 2022-10-26
+
+### 📚 3rd party library updates
+
+- Added `terser-webpack-plugin@5.3.5`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juanchigallego](https://github.com/juanchigallego))
+- Added `ts-loader@9.3.1`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juanchigallego](https://github.com/juanchigallego))
+- Added `typescript@4.7.4`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juanchigallego](https://github.com/juanchigallego))
+- Added `webpack@5.74.0`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juanchigallego](https://github.com/juanchigallego))
+- Added `webpack-cli@4.10.0`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juanchigallego](https://github.com/juanchigallego))
+
+### 🎉 New features
+
+- Added `position`, `padding`, `children`, `onRemove`, and `open` properties to the Component. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
+- Added stories on Component. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
+- Created new `Sidebar.Header` subcomponent. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `children`, and `title` properties to the Component `Sidebar.Header`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
+- Created new `Sidebar.Body` subcomponent. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `children`, and `padding` properties to the Component `Sidebar.Body`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
+- Created new `Sidebar.Footer` subcomponent. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `children` properties to the Component `Sidebar.Footer`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))

--- a/packages/react/Sidebar/README.md
+++ b/packages/react/Sidebar/README.md
@@ -1,0 +1,13 @@
+# `@nimbus-ds/sidebar`
+
+[![@nimbus-ds/sidebar](https://img.shields.io/npm/v/@nimbus-ds/sidebar?label=%40nimbus-ds%2Fsidebar)](https://www.npmjs.com/package/@nimbus-ds/sidebar)
+
+Sidebars navigation provides access to the parts within its application. The side sections have the supplementary content that is linked on the left or right side of the screen.
+
+## Installation
+
+```sh
+$ yarn add @nimbus-ds/sidebar
+# or
+$ npm install @nimbus-ds/sidebar
+```

--- a/packages/react/Sidebar/package.json
+++ b/packages/react/Sidebar/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@nimbus-ds/sidebar",
+  "version": "0.0.0",
+  "license": "MIT",
+  "source": "src/index.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.module.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "yarn build:types && webpack",
+    "build:types": "tsc --emitDeclarationOnly --declaration true --declarationDir ./dist --baseUrl ../../../",
+    "clean": "rm -rf dist",
+    "version": "yarn version"
+  },
+  "dependencies": {
+    "@nimbus-ds/title": "workspace:^",
+    "@nimbus-ds/styles": "workspace:^"
+  },
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  },
+  "homepage": "https://nimbus.nuvemshop.com.br/documentation",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TiendaNube/nimbus-design-system.git"
+  },
+  "bugs": {
+    "url": "https://github.com/TiendaNube/nimbus-design-system/issues"
+  },
+  "devDependencies": {
+    "@nimbus-ds/box": "workspace:^",
+    "@nimbus-ds/button": "workspace:^",
+    "@nimbus-ds/text": "workspace:^",
+    "@nimbus-ds/stack": "workspace:^",
+    "terser-webpack-plugin": "^5.3.5",
+    "ts-loader": "^9.3.1",
+    "typescript": "^4.7.4",
+    "webpack": "^5.74.0",
+    "webpack-cli": "^4.10.0"
+  }
+}

--- a/packages/react/Sidebar/package.json
+++ b/packages/react/Sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/sidebar",
-  "version": "0.0.0",
+  "version": "1.0.0-rc.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -43,5 +43,6 @@
     "typescript": "^4.7.4",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
-  }
+  },
+  "stableVersion": "0.0.0"
 }

--- a/packages/react/Sidebar/package.json
+++ b/packages/react/Sidebar/package.json
@@ -18,8 +18,8 @@
     "version": "yarn version"
   },
   "dependencies": {
-    "@nimbus-ds/styles": "workspace:^",
-    "@nimbus-ds/title": "workspace:^"
+    "@nimbus-ds/styles": "workspace:*",
+    "@nimbus-ds/title": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0 || ^18.0",
@@ -34,10 +34,10 @@
     "url": "https://github.com/TiendaNube/nimbus-design-system/issues"
   },
   "devDependencies": {
-    "@nimbus-ds/box": "workspace:^",
-    "@nimbus-ds/button": "workspace:^",
-    "@nimbus-ds/stack": "workspace:^",
-    "@nimbus-ds/text": "workspace:^",
+    "@nimbus-ds/box": "workspace:*",
+    "@nimbus-ds/button": "workspace:*",
+    "@nimbus-ds/stack": "workspace:*",
+    "@nimbus-ds/text": "workspace:*",
     "terser-webpack-plugin": "^5.3.5",
     "ts-loader": "^9.3.1",
     "typescript": "^4.7.4",

--- a/packages/react/Sidebar/package.json
+++ b/packages/react/Sidebar/package.json
@@ -18,8 +18,8 @@
     "version": "yarn version"
   },
   "dependencies": {
-    "@nimbus-ds/title": "workspace:^",
-    "@nimbus-ds/styles": "workspace:^"
+    "@nimbus-ds/styles": "workspace:^",
+    "@nimbus-ds/title": "workspace:^"
   },
   "peerDependencies": {
     "react": "^16.8 || ^17.0 || ^18.0",
@@ -36,8 +36,8 @@
   "devDependencies": {
     "@nimbus-ds/box": "workspace:^",
     "@nimbus-ds/button": "workspace:^",
-    "@nimbus-ds/text": "workspace:^",
     "@nimbus-ds/stack": "workspace:^",
+    "@nimbus-ds/text": "workspace:^",
     "terser-webpack-plugin": "^5.3.5",
     "ts-loader": "^9.3.1",
     "typescript": "^4.7.4",

--- a/packages/react/Sidebar/src/Sidebar.tsx
+++ b/packages/react/Sidebar/src/Sidebar.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { FloatingPortal } from "@floating-ui/react-dom-interactions";
+import { sidebar } from "@nimbus-ds/styles";
+
+import { Body, Footer, Header } from "./components";
+import { SidebarComponents, SidebarProps } from "./sidebar.types";
+
+const Sidebar: React.FC<SidebarProps> & SidebarComponents = ({
+  className: _className,
+  style: _style,
+  title,
+  position = "right",
+  padding = "none",
+  open = false,
+  children,
+  onRemove,
+  ...rest
+}: SidebarProps) => (
+  <FloatingPortal id="nimbus-sidebar">
+    <div
+      {...rest}
+      role={rest.role || "presentation"}
+      className={[
+        sidebar.style.container,
+        sidebar.style.positions[position],
+        sidebar.sprinkle({ padding }),
+        open && sidebar.style.isVisible,
+      ].join(" ")}
+    >
+      {children}
+    </div>
+    {open && (
+      <button
+        aria-label="overlay"
+        data-testid="overlay-sidebar-button"
+        type="button"
+        className={sidebar.style.overlay}
+        onClick={onRemove}
+      />
+    )}
+  </FloatingPortal>
+);
+
+Sidebar.Body = Body;
+Sidebar.Footer = Footer;
+Sidebar.Header = Header;
+Sidebar.displayName = "Sidebar";
+Sidebar.Body.displayName = "Sidebar.Body";
+Sidebar.Footer.displayName = "Sidebar.Footer";
+Sidebar.Header.displayName = "Sidebar.Header";
+
+export { Sidebar };

--- a/packages/react/Sidebar/src/components/Body/Body.tsx
+++ b/packages/react/Sidebar/src/components/Body/Body.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { sidebar } from "@nimbus-ds/styles";
+
+import { BodyProps } from "./body.types";
+
+const Body: React.FC<BodyProps> = ({
+  className: _className,
+  style: _style,
+  padding = "none",
+  children,
+  ...rest
+}) => (
+  <div className={sidebar.sprinkle({ padding })} {...rest}>
+    {children}
+  </div>
+);
+
+export { Body };

--- a/packages/react/Sidebar/src/components/Body/body.spec.tsx
+++ b/packages/react/Sidebar/src/components/Body/body.spec.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { Body } from "./Body";
+import { BodyProps } from "./body.types";
+
+const makeSut = (props: BodyProps) => {
+  render(<Body {...props} data-testid="body-element" />);
+};
+
+describe("GIVEN <Body />", () => {
+  describe("WHEN rendered", () => {
+    it("THEN should render the submitted content", () => {
+      makeSut({ children: "My content" });
+      expect(screen.getByText("My content")).toBeDefined();
+    });
+  });
+
+  describe("THEN should correctly render the submitted padding", () => {
+    it("THEN should correctly render the padding default", () => {
+      makeSut({ children: "My content" });
+      expect(
+        screen.getByTestId("body-element").getAttribute("class")
+      ).toContain("padding_none");
+    });
+
+    it("THEN should correctly render the padding none", () => {
+      makeSut({ padding: "none", children: "My content" });
+      expect(
+        screen.getByTestId("body-element").getAttribute("class")
+      ).toContain("padding_none");
+    });
+
+    it("THEN should correctly render the padding base", () => {
+      makeSut({ padding: "base", children: "My content" });
+      expect(
+        screen.getByTestId("body-element").getAttribute("class")
+      ).toContain("padding_base");
+    });
+  });
+});

--- a/packages/react/Sidebar/src/components/Body/body.types.ts
+++ b/packages/react/Sidebar/src/components/Body/body.types.ts
@@ -1,0 +1,9 @@
+import { HTMLAttributes, ReactNode } from "react";
+import { sidebar } from "@nimbus-ds/styles";
+
+export interface BodyProps extends HTMLAttributes<HTMLElement> {
+  /** Body content */
+  children: ReactNode;
+  /** Sidebar padding */
+  padding?: keyof typeof sidebar.properties.padding;
+}

--- a/packages/react/Sidebar/src/components/Body/index.ts
+++ b/packages/react/Sidebar/src/components/Body/index.ts
@@ -1,0 +1,4 @@
+import { Body } from "./Body";
+
+export { Body } from "./Body";
+export default Body;

--- a/packages/react/Sidebar/src/components/Footer/Footer.tsx
+++ b/packages/react/Sidebar/src/components/Footer/Footer.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { sidebar } from "@nimbus-ds/styles";
+
+import { FooterProps } from "./footer.types";
+
+const Footer: React.FC<FooterProps> = ({
+  className: _className,
+  style: _style,
+  children,
+  ...rest
+}) => (
+  <div className={sidebar.style.footer} {...rest}>
+    {children}
+  </div>
+);
+
+export { Footer };

--- a/packages/react/Sidebar/src/components/Footer/footer.spec.tsx
+++ b/packages/react/Sidebar/src/components/Footer/footer.spec.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { Footer } from "./Footer";
+import { FooterProps } from "./footer.types";
+
+const makeSut = (props: FooterProps) => {
+  render(<Footer {...props} data-testid="footer-element" />);
+};
+
+describe("GIVEN <Footer />", () => {
+  describe("WHEN rendered", () => {
+    it("THEN should render the submitted content", () => {
+      makeSut({ children: "My content" });
+      expect(screen.getByText("My content")).toBeDefined();
+    });
+  });
+});

--- a/packages/react/Sidebar/src/components/Footer/footer.types.ts
+++ b/packages/react/Sidebar/src/components/Footer/footer.types.ts
@@ -1,0 +1,6 @@
+import { HTMLAttributes, ReactNode } from "react";
+
+export interface FooterProps extends HTMLAttributes<HTMLElement> {
+  /** Footer content */
+  children: ReactNode;
+}

--- a/packages/react/Sidebar/src/components/Footer/index.ts
+++ b/packages/react/Sidebar/src/components/Footer/index.ts
@@ -1,0 +1,4 @@
+import { Footer } from "./Footer";
+
+export { Footer } from "./Footer";
+export default Footer;

--- a/packages/react/Sidebar/src/components/Header/Header.tsx
+++ b/packages/react/Sidebar/src/components/Header/Header.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Title } from "@nimbus-ds/title";
+import { sidebar } from "@nimbus-ds/styles";
+
+import { HeaderProps } from "./header.types";
+
+const Header: React.FC<HeaderProps> = ({
+  className: _className,
+  style: _style,
+  title,
+  children,
+  ...rest
+}) => (
+  <div {...rest} className={sidebar.style.header}>
+    {title && <Title data-testid="header-title">{title}</Title>}
+    {children}
+  </div>
+);
+
+export { Header };

--- a/packages/react/Sidebar/src/components/Header/header.spec.tsx
+++ b/packages/react/Sidebar/src/components/Header/header.spec.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { Header } from "./Header";
+import { HeaderProps } from "./header.types";
+
+const makeSut = (props?: HeaderProps) => {
+  render(<Header {...props} data-testid="header-element" />);
+};
+
+describe("GIVEN <Header />", () => {
+  describe("WHEN rendered", () => {
+    it("THEN should render the submitted title", () => {
+      makeSut({ title: "My Title" });
+      expect(screen.getByText("My Title")).toBeDefined();
+      expect(screen.getByTestId("header-title")).toBeDefined();
+    });
+    it("THEN should not render the submitted title", () => {
+      makeSut();
+      expect(screen.queryByTestId("header-title")).toBeNull();
+    });
+  });
+});

--- a/packages/react/Sidebar/src/components/Header/header.types.ts
+++ b/packages/react/Sidebar/src/components/Header/header.types.ts
@@ -1,0 +1,8 @@
+import { HTMLAttributes, ReactNode } from "react";
+
+export interface HeaderProps extends HTMLAttributes<HTMLElement> {
+  /** Header content */
+  children?: ReactNode;
+  /** Header title */
+  title?: string;
+}

--- a/packages/react/Sidebar/src/components/Header/index.ts
+++ b/packages/react/Sidebar/src/components/Header/index.ts
@@ -1,0 +1,4 @@
+import { Header } from "./Header";
+
+export { Header } from "./Header";
+export default Header;

--- a/packages/react/Sidebar/src/components/index.ts
+++ b/packages/react/Sidebar/src/components/index.ts
@@ -1,0 +1,3 @@
+export * from "./Body";
+export * from "./Footer";
+export * from "./Header";

--- a/packages/react/Sidebar/src/index.ts
+++ b/packages/react/Sidebar/src/index.ts
@@ -1,0 +1,6 @@
+import { Sidebar } from "./Sidebar";
+import "@nimbus-ds/styles/packages/sidebar/index.css";
+
+export { Sidebar } from "./Sidebar";
+export type { SidebarProps } from "./sidebar.types";
+export default Sidebar;

--- a/packages/react/Sidebar/src/sidebar.spec.tsx
+++ b/packages/react/Sidebar/src/sidebar.spec.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { Sidebar } from "./Sidebar";
+import { SidebarProps } from "./sidebar.types";
+
+const mockedRemoveAlert = jest.fn();
+
+const makeSut = (rest: SidebarProps) => {
+  render(<Sidebar {...rest} data-testid="sidebar-element" />);
+};
+
+describe("GIVEN <Sidebar />", () => {
+  describe("WHEN rendered", () => {
+    it("THEN should correctly render the submitted content", () => {
+      makeSut({ children: <div>My content</div> });
+      expect(screen.getByText("My content")).toBeDefined();
+    });
+
+    it("THEN should correctly execute the onRemove function", () => {
+      makeSut({
+        children: <div>My content</div>,
+        open: true,
+        onRemove: mockedRemoveAlert,
+      });
+      const dismissButton = screen.getByTestId("overlay-sidebar-button");
+      fireEvent.click(dismissButton);
+      expect(mockedRemoveAlert).toBeCalled();
+    });
+  });
+
+  describe("THEN should correctly render or not based on the open property", () => {
+    it("THEN should correctly render if open is true", () => {
+      makeSut({ children: <div>My content</div>, open: true });
+      expect(screen.getByTestId("overlay-sidebar-button")).toBeTruthy();
+      expect(
+        screen.getByTestId("sidebar-element").getAttribute("class")
+      ).toContain("isVisible");
+    });
+
+    it("THEN should not render if open is false", () => {
+      makeSut({ children: <div>My content</div>, open: false });
+      expect(screen.queryByTestId("overlay-sidebar-button")).toBeNull();
+    });
+  });
+});

--- a/packages/react/Sidebar/src/sidebar.stories.tsx
+++ b/packages/react/Sidebar/src/sidebar.stories.tsx
@@ -1,0 +1,230 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { withA11y } from "@storybook/addon-a11y";
+// eslint-disable-next-line
+import { useArgs } from "@storybook/client-api";
+import { Box } from "@nimbus-ds/box";
+import { Button } from "@nimbus-ds/button";
+import { Text } from "@nimbus-ds/text";
+import { Stack } from "@nimbus-ds/stack";
+
+import { Sidebar } from "./Sidebar";
+
+export default {
+  title: "Composite/Sidebar",
+  component: Sidebar,
+  subcomponents: {
+    "Sidebar.Header": Sidebar.Header,
+    "Sidebar.Body": Sidebar.Body,
+    "Sidebar.Footer": Sidebar.Footer,
+  },
+  argTypes: {
+    children: { control: { disable: true } },
+  },
+  parameters: {
+    withA11y: { decorators: [withA11y] },
+  },
+} as ComponentMeta<typeof Sidebar>;
+
+const Template: ComponentStory<typeof Sidebar> = (args) => {
+  const [{ open }, updateArgs] = useArgs();
+  const handleClose = () => updateArgs({ open: !open });
+  return (
+    <>
+      <Button onClick={handleClose}>Open</Button>
+      <Sidebar {...args} onRemove={handleClose} open={open} />
+    </>
+  );
+};
+
+export const base = Template.bind({});
+base.args = {
+  children: (
+    <Box
+      borderStyle="dashed"
+      padding="0.5rem"
+      borderWidth="1px"
+      borderColor="neutral.interactive"
+      height="100%"
+    >
+      <Stack
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        height="100%"
+      >
+        <Text textAlign="center" fontSize="base">
+          Replace me with your content
+        </Text>
+      </Stack>
+    </Box>
+  ),
+};
+
+export const withPadding = Template.bind({});
+withPadding.args = {
+  padding: "base",
+  children: (
+    <Box
+      borderStyle="dashed"
+      padding="0.5rem"
+      borderWidth="1px"
+      borderColor="neutral.interactive"
+      height="100%"
+    >
+      <Stack
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        height="100%"
+      >
+        <Text textAlign="center" fontSize="base">
+          Replace me with your content
+        </Text>
+      </Stack>
+    </Box>
+  ),
+};
+
+export const withHeader = Template.bind({});
+withHeader.args = {
+  padding: "base",
+  children: (
+    <>
+      <Sidebar.Header>
+        <Box
+          borderStyle="dashed"
+          padding="0.5rem"
+          borderWidth="1px"
+          borderColor="neutral.interactive"
+          height="100%"
+        >
+          <Stack
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            height="100%"
+          >
+            <Text textAlign="center" fontSize="base">
+              Header
+            </Text>
+          </Stack>
+        </Box>
+      </Sidebar.Header>
+      <Box
+        borderStyle="dashed"
+        padding="0.5rem"
+        borderWidth="1px"
+        borderColor="neutral.interactive"
+        height="100%"
+      >
+        <Stack
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          height="100%"
+        >
+          <Text textAlign="center" fontSize="base">
+            Body
+          </Text>
+        </Stack>
+      </Box>
+    </>
+  ),
+};
+
+export const withHeaderAndTitle = Template.bind({});
+withHeaderAndTitle.args = {
+  padding: "base",
+  children: (
+    <>
+      <Sidebar.Header title="Title" />
+      <Box
+        borderStyle="dashed"
+        padding="0.5rem"
+        borderWidth="1px"
+        borderColor="neutral.interactive"
+        height="100%"
+      >
+        <Stack
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          height="100%"
+        >
+          <Text textAlign="center" fontSize="base">
+            Replace me with your content
+          </Text>
+        </Stack>
+      </Box>
+    </>
+  ),
+};
+
+export const withFooter = Template.bind({});
+withFooter.args = {
+  padding: "base",
+  children: (
+    <>
+      <Sidebar.Header>
+        <Box
+          borderStyle="dashed"
+          padding="0.5rem"
+          borderWidth="1px"
+          borderColor="neutral.interactive"
+          height="100%"
+        >
+          <Stack
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            height="100%"
+          >
+            <Text textAlign="center" fontSize="base">
+              Header
+            </Text>
+          </Stack>
+        </Box>
+      </Sidebar.Header>
+      <Box
+        borderStyle="dashed"
+        padding="0.5rem"
+        borderWidth="1px"
+        borderColor="neutral.interactive"
+        height="100%"
+      >
+        <Stack
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          height="100%"
+        >
+          <Text textAlign="center" fontSize="base">
+            Body
+          </Text>
+        </Stack>
+      </Box>
+      <Sidebar.Footer>
+        <Box
+          borderStyle="dashed"
+          padding="0.5rem"
+          borderWidth="1px"
+          borderColor="neutral.interactive"
+          height="100%"
+          width="100%"
+        >
+          <Stack
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            height="100%"
+          >
+            <Text textAlign="center" fontSize="base">
+              Footer
+            </Text>
+          </Stack>
+        </Box>
+      </Sidebar.Footer>
+    </>
+  ),
+};

--- a/packages/react/Sidebar/src/sidebar.types.ts
+++ b/packages/react/Sidebar/src/sidebar.types.ts
@@ -1,0 +1,22 @@
+import { HTMLAttributes, ReactNode } from "react";
+import { sidebar } from "@nimbus-ds/styles";
+import { Body, Footer, Header } from "./components";
+
+export interface SidebarComponents {
+  Body: typeof Body;
+  Footer: typeof Footer;
+  Header: typeof Header;
+}
+
+export interface SidebarProps extends HTMLAttributes<HTMLElement> {
+  /** Sidebar position */
+  position?: "right" | "left";
+  /** Sidebar padding */
+  padding?: keyof typeof sidebar.properties.padding;
+  /** Sidebar body content */
+  children: ReactNode;
+  /** Function to be passed on actioning the dismiss button */
+  onRemove?: () => void;
+  /** Controls the menu display */
+  open?: boolean;
+}

--- a/packages/react/Sidebar/tsconfig.json
+++ b/packages/react/Sidebar/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./src"],
+  "exclude": ["src/**/*.spec.tsx", "src/**/*.stories.tsx"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declaration": false,
+    "paths": {
+      "@nimbus-ds/button": ["../Button/src"],
+      "@nimbus-ds/box": ["../Box/src"],
+      "@nimbus-ds/stack": ["../Stack/src"],
+      "@nimbus-ds/text": ["../Text/src"],
+      "@nimbus-ds/title": ["../Title/src"],
+      "@nimbus-ds/styles": ["../../styles/src"]
+    }
+  }
+}

--- a/packages/react/Sidebar/webpack.config.js
+++ b/packages/react/Sidebar/webpack.config.js
@@ -1,0 +1,48 @@
+const path = require("path");
+const { VanillaExtractPlugin } = require("@vanilla-extract/webpack-plugin");
+const TerserJSPlugin = require("terser-webpack-plugin");
+
+module.exports = {
+  mode: "development",
+  devtool: "source-map",
+  entry: {
+    "./index": "./src/index.ts",
+  },
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: "[name].js",
+    libraryTarget: "umd",
+    library: "@nimbus-ds/sidebar",
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: "ts-loader",
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.css$/i,
+        use: ["style-loader", "css-loader"],
+      },
+    ],
+  },
+  plugins: [new VanillaExtractPlugin()],
+  resolve: {
+    alias: {
+      "@nimbus-ds/styles": path.resolve(__dirname, "../../styles/dist"),
+      "@nimbus-ds/title": path.resolve(__dirname, "../Title/src"),
+    },
+    extensions: [".tsx", ".ts", ".js"],
+  },
+  optimization: {
+    minimize: true,
+    minimizer: [new TerserJSPlugin()],
+  },
+  externals: {
+    "@nimbus-ds/title": "@nimbus-ds/title",
+    "@nimbus-ds/styles": "@nimbus-ds/styles",
+    react: "react",
+    "react-dom": "react-dom",
+  },
+};

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus Styles deprive all styles needed to build nimbus components.
 
+## 2022-11-16 `4.16.0`
+
+### 🎉 New features
+
+- Added new style pack for sidebar component. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/#56) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2022-11-02 `4.15.0`
 
 ### 🐛 Bug fixes

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -8,6 +8,10 @@ Nimbus Styles deprive all styles needed to build nimbus components.
 
 - Added new style pack for sidebar component. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/#56) by [@juniorconquista](https://github.com/juniorconquista))
 
+### 🐛 Bug fixes
+
+- Added `box-sizing` to box component styling. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/#56) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2022-11-02 `4.15.0`
 
 ### 🐛 Bug fixes

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/styles",
-  "version": "4.14.1",
+  "version": "4.15.0-rc.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -38,5 +38,6 @@
     "ts-loader": "^9.3.1",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
-  }
+  },
+  "stableVersion": "4.14.1"
 }

--- a/packages/styles/src/index.ts
+++ b/packages/styles/src/index.ts
@@ -19,6 +19,7 @@ export { list } from "./packages/list";
 export { popover } from "./packages/popover";
 export { radio } from "./packages/radio";
 export { select } from "./packages/select";
+export { sidebar } from "./packages/sidebar";
 export { skeleton } from "./packages/skeleton";
 export { spinner } from "./packages/spinner";
 export { stack } from "./packages/stack";

--- a/packages/styles/src/packages/box/box.style.css.ts
+++ b/packages/styles/src/packages/box/box.style.css.ts
@@ -1,0 +1,5 @@
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+  boxSizing: "border-box",
+});

--- a/packages/styles/src/packages/box/index.ts
+++ b/packages/styles/src/packages/box/index.ts
@@ -1,3 +1,4 @@
+import * as style from "./box.style.css";
 import {
   sprinkle,
   backgroundColorProperties,
@@ -8,6 +9,7 @@ import {
 } from "./box.sprinkle.css";
 
 export const box = {
+  style,
   sprinkle,
   properties: {
     backgroundColor: backgroundColorProperties,

--- a/packages/styles/src/packages/sidebar/index.ts
+++ b/packages/styles/src/packages/sidebar/index.ts
@@ -1,0 +1,10 @@
+import * as style from "./sidebar.style.css";
+import { paddingProperties, sprinkle } from "./sidebar.sprinkle.css";
+
+export const sidebar = {
+  style,
+  sprinkle,
+  properties: {
+    padding: paddingProperties,
+  },
+};

--- a/packages/styles/src/packages/sidebar/sidebar.sprinkle.css.ts
+++ b/packages/styles/src/packages/sidebar/sidebar.sprinkle.css.ts
@@ -1,0 +1,15 @@
+import { defineProperties, createSprinkles } from "@vanilla-extract/sprinkles";
+import { varsThemeBase } from "../../themes/base.css";
+
+export const paddingProperties = {
+  base: varsThemeBase.spacing[4],
+  none: 0,
+};
+
+export const sprinkle = createSprinkles(
+  defineProperties({
+    properties: {
+      padding: paddingProperties,
+    },
+  })
+);

--- a/packages/styles/src/packages/sidebar/sidebar.style.css.ts
+++ b/packages/styles/src/packages/sidebar/sidebar.style.css.ts
@@ -1,0 +1,67 @@
+import { style, styleVariants, keyframes } from "@vanilla-extract/css";
+
+import { varsThemeBase } from "../../themes/base.css";
+
+const overlayAnimation = keyframes({
+  "0%": {
+    opacity: 0,
+  },
+  "100%": {
+    opacity: 1,
+  },
+});
+
+export const overlay = style({
+  position: "fixed",
+  backgroundColor: "rgba(0, 0, 0, 0.5)",
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+  zIndex: 100,
+  animation: `${overlayAnimation} 0.5s ease`,
+});
+
+export const container = style({
+  position: "fixed",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "stretch",
+  backgroundColor: "#FFFFFF",
+  height: "100%",
+  minHeight: "100%",
+  maxWidth: "375px",
+  width: "100%",
+  zIndex: 200,
+  top: 0,
+  opacity: 0,
+  transition: `opacity ${varsThemeBase.motion.speed.base} ease, transform ${varsThemeBase.motion.speed.base} ease`,
+  boxSizing: "border-box",
+});
+
+export const positions = styleVariants({
+  left: {
+    left: 0,
+    transform: "translateX(-100%)",
+  },
+  right: {
+    right: 0,
+    transform: "translateX(100%)",
+  },
+});
+
+export const isVisible = style({
+  opacity: 1,
+  transform: "translateX(0)",
+});
+
+export const header = style({
+  marginBottom: "1rem",
+});
+
+export const footer = style({
+  width: "100%",
+  display: "flex",
+  gap: varsThemeBase.spacing[2],
+  marginTop: "1rem",
+});

--- a/packages/styles/webpack.config.js
+++ b/packages/styles/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = {
     "./packages/iconButton/index": "./src/packages/iconButton/index",
     "./packages/input/index": "./src/packages/input/index",
     "./packages/label/index": "./src/packages/label/index",
+    "./packages/sidebar/index": "./src/packages/sidebar/index",
     "./packages/skeleton/index": "./src/packages/skeleton/index",
     "./packages/spinner/index": "./src/packages/spinner/index",
     "./packages/stack/index": "./src/packages/stack/index",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2800,7 +2800,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/box@workspace:*, @nimbus-ds/box@workspace:^, @nimbus-ds/box@workspace:packages/react/Box":
+"@nimbus-ds/box@workspace:*, @nimbus-ds/box@workspace:packages/react/Box":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/box@workspace:packages/react/Box"
   dependencies:
@@ -2817,7 +2817,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/button@workspace:*, @nimbus-ds/button@workspace:^, @nimbus-ds/button@workspace:packages/react/Button":
+"@nimbus-ds/button@workspace:*, @nimbus-ds/button@workspace:packages/react/Button":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/button@workspace:packages/react/Button"
   dependencies:
@@ -3089,12 +3089,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/sidebar@workspace:packages/react/Sidebar"
   dependencies:
-    "@nimbus-ds/box": "workspace:^"
-    "@nimbus-ds/button": "workspace:^"
-    "@nimbus-ds/stack": "workspace:^"
-    "@nimbus-ds/styles": "workspace:^"
-    "@nimbus-ds/text": "workspace:^"
-    "@nimbus-ds/title": "workspace:^"
+    "@nimbus-ds/box": "workspace:*"
+    "@nimbus-ds/button": "workspace:*"
+    "@nimbus-ds/stack": "workspace:*"
+    "@nimbus-ds/styles": "workspace:*"
+    "@nimbus-ds/text": "workspace:*"
+    "@nimbus-ds/title": "workspace:*"
     terser-webpack-plugin: ^5.3.5
     ts-loader: ^9.3.1
     typescript: ^4.7.4
@@ -3141,7 +3141,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/stack@workspace:*, @nimbus-ds/stack@workspace:^, @nimbus-ds/stack@workspace:packages/react/Stack":
+"@nimbus-ds/stack@workspace:*, @nimbus-ds/stack@workspace:packages/react/Stack":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/stack@workspace:packages/react/Stack"
   dependencies:
@@ -3159,7 +3159,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/styles@workspace:*, @nimbus-ds/styles@workspace:^, @nimbus-ds/styles@workspace:packages/styles":
+"@nimbus-ds/styles@workspace:*, @nimbus-ds/styles@workspace:packages/styles":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/styles@workspace:packages/styles"
   dependencies:
@@ -3196,7 +3196,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/text@workspace:*, @nimbus-ds/text@workspace:^, @nimbus-ds/text@workspace:packages/react/Text":
+"@nimbus-ds/text@workspace:*, @nimbus-ds/text@workspace:packages/react/Text":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/text@workspace:packages/react/Text"
   dependencies:
@@ -3251,7 +3251,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/title@workspace:*, @nimbus-ds/title@workspace:^, @nimbus-ds/title@workspace:packages/react/Title":
+"@nimbus-ds/title@workspace:*, @nimbus-ds/title@workspace:packages/react/Title":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/title@workspace:packages/react/Title"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,8 +3091,10 @@ __metadata:
   dependencies:
     "@nimbus-ds/box": "workspace:^"
     "@nimbus-ds/button": "workspace:^"
+    "@nimbus-ds/stack": "workspace:^"
     "@nimbus-ds/styles": "workspace:^"
     "@nimbus-ds/text": "workspace:^"
+    "@nimbus-ds/title": "workspace:^"
     terser-webpack-plugin: ^5.3.5
     ts-loader: ^9.3.1
     typescript: ^4.7.4
@@ -3139,7 +3141,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/stack@workspace:*, @nimbus-ds/stack@workspace:packages/react/Stack":
+"@nimbus-ds/stack@workspace:*, @nimbus-ds/stack@workspace:^, @nimbus-ds/stack@workspace:packages/react/Stack":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/stack@workspace:packages/react/Stack"
   dependencies:
@@ -3249,7 +3251,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/title@workspace:*, @nimbus-ds/title@workspace:packages/react/Title":
+"@nimbus-ds/title@workspace:*, @nimbus-ds/title@workspace:^, @nimbus-ds/title@workspace:packages/react/Title":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/title@workspace:packages/react/Title"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2800,7 +2800,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/box@workspace:*, @nimbus-ds/box@workspace:packages/react/Box":
+"@nimbus-ds/box@workspace:*, @nimbus-ds/box@workspace:^, @nimbus-ds/box@workspace:packages/react/Box":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/box@workspace:packages/react/Box"
   dependencies:
@@ -2817,7 +2817,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/button@workspace:*, @nimbus-ds/button@workspace:packages/react/Button":
+"@nimbus-ds/button@workspace:*, @nimbus-ds/button@workspace:^, @nimbus-ds/button@workspace:packages/react/Button":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/button@workspace:packages/react/Button"
   dependencies:
@@ -3085,6 +3085,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@nimbus-ds/sidebar@workspace:packages/react/Sidebar":
+  version: 0.0.0-use.local
+  resolution: "@nimbus-ds/sidebar@workspace:packages/react/Sidebar"
+  dependencies:
+    "@nimbus-ds/box": "workspace:^"
+    "@nimbus-ds/button": "workspace:^"
+    "@nimbus-ds/styles": "workspace:^"
+    "@nimbus-ds/text": "workspace:^"
+    terser-webpack-plugin: ^5.3.5
+    ts-loader: ^9.3.1
+    typescript: ^4.7.4
+    webpack: ^5.74.0
+    webpack-cli: ^4.10.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  languageName: unknown
+  linkType: soft
+
 "@nimbus-ds/skeleton@workspace:*, @nimbus-ds/skeleton@workspace:packages/react/Skeleton":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/skeleton@workspace:packages/react/Skeleton"
@@ -3138,7 +3157,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/styles@workspace:*, @nimbus-ds/styles@workspace:packages/styles":
+"@nimbus-ds/styles@workspace:*, @nimbus-ds/styles@workspace:^, @nimbus-ds/styles@workspace:packages/styles":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/styles@workspace:packages/styles"
   dependencies:
@@ -3175,7 +3194,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nimbus-ds/text@workspace:*, @nimbus-ds/text@workspace:packages/react/Text":
+"@nimbus-ds/text@workspace:*, @nimbus-ds/text@workspace:^, @nimbus-ds/text@workspace:packages/react/Text":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/text@workspace:packages/react/Text"
   dependencies:


### PR DESCRIPTION
# ECNIM-532

## Type

- [ ] Bugfix 🐛
- [x] New feature 🌈
- [ ] Change request 🤓
- [x] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

### `@nimbus-ds/sidebar`

#### 📚 3rd party library updates

- Added `terser-webpack-plugin@5.3.5`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juanchigallego](https://github.com/juanchigallego))
- Added `ts-loader@9.3.1`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juanchigallego](https://github.com/juanchigallego))
- Added `typescript@4.7.4`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juanchigallego](https://github.com/juanchigallego))
- Added `webpack@5.74.0`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juanchigallego](https://github.com/juanchigallego))
- Added `webpack-cli@4.10.0`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juanchigallego](https://github.com/juanchigallego))

#### 🎉 New features

- Added `position`, `padding`, `children`, `onRemove`, and `open` properties to the Component. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
- Added stories on Component. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
- Created new `Sidebar.Header` subcomponent. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
- Added `children`, and `title` properties to the Component `Sidebar.Header`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
- Created new `Sidebar.Body` subcomponent. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
- Added `children`, and `padding` properties to the Component `Sidebar.Body`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
- Created new `Sidebar.Footer` subcomponent. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))
- Added `children` properties to the Component `Sidebar.Footer`. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))

### `@nimbus-ds/styles`

#### 🎉 New features

- Added new style pack for sidebar component. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/#56) by [@juniorconquista](https://github.com/juniorconquista))

#### 🐛 Bug fixes

- Added `box-sizing` to box component styling. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/#56) by [@juniorconquista](https://github.com/juniorconquista))

### `@nimbus-ds/box`

#### 🐛 Bug fixes

- Added `box-sizing` to component styling. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/#56) by [@juniorconquista](https://github.com/juniorconquista))

### `@nimbus-ds/box`

#### 🐛 Bug fixes

- Externalizing component build style pack. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/#56) by [@juniorconquista](https://github.com/juniorconquista))

### `@nimbus-ds/icon-button`

#### 🐛 Bug fixes

- Updating internal version of @nimbus-ds/icon package. ([#56](https://github.com/TiendaNube/nimbus-design-system/pull/56) by [@juniorconquista](https://github.com/juniorconquista))


## Screenshots 🏞

## Related issues 🐛
