### PR TITLE
[BUG] Link underlined when textDecoration "none" and href defined

### DIFF
--- a/.yarn/versions/122987b1.yml
+++ b/.yarn/versions/122987b1.yml
@@ -1,0 +1,35 @@
+releases:
+  "@nimbus-ds/components": patch
+  "@nimbus-ds/link": patch
+  "@nimbus-ds/styles": minor
+
+declined:
+  - "@nimbus-ds/badge"
+  - "@nimbus-ds/box"
+  - "@nimbus-ds/button"
+  - "@nimbus-ds/checkbox"
+  - "@nimbus-ds/chip"
+  - "@nimbus-ds/file-uploader"
+  - "@nimbus-ds/icon"
+  - "@nimbus-ds/icon-button"
+  - "@nimbus-ds/input"
+  - "@nimbus-ds/label"
+  - "@nimbus-ds/list"
+  - "@nimbus-ds/popover"
+  - "@nimbus-ds/radio"
+  - "@nimbus-ds/select"
+  - "@nimbus-ds/skeleton"
+  - "@nimbus-ds/spinner"
+  - "@nimbus-ds/stack"
+  - "@nimbus-ds/tag"
+  - "@nimbus-ds/text"
+  - "@nimbus-ds/textarea"
+  - "@nimbus-ds/thumbnail"
+  - "@nimbus-ds/title"
+  - "@nimbus-ds/toast"
+  - "@nimbus-ds/toggle"
+  - "@nimbus-ds/tooltip"
+  - "@nimbus-ds/alert"
+  - "@nimbus-ds/card"
+  - "@nimbus-ds/sidebar"
+  - "@nimbus-ds/tabs"

--- a/.yarn/versions/122987b1.yml
+++ b/.yarn/versions/122987b1.yml
@@ -4,6 +4,7 @@ releases:
   "@nimbus-ds/styles": minor
 
 declined:
+  - nimbus-design-system
   - "@nimbus-ds/badge"
   - "@nimbus-ds/box"
   - "@nimbus-ds/button"

--- a/packages/core/styles/CHANGELOG.md
+++ b/packages/core/styles/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus Styles deprive all styles needed to build nimbus components.
 
+## 2022-12-15 `5.1.0`
+
+### 🎉 New features
+
+- Added `none` and `underline` options in `textDecoration` property in sprinkle link. ([#64](https://github.com/TiendaNube/nimbus-design-system/pull/64) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2022-12-07 `5.0.0`
 
 ### 🎉 New features

--- a/packages/core/styles/CHANGELOG.md
+++ b/packages/core/styles/CHANGELOG.md
@@ -6,7 +6,7 @@ Nimbus Styles deprive all styles needed to build nimbus components.
 
 ### 🎉 New features
 
-- Added `none` and `underline` options in `textDecoration` property in sprinkle link. ([#64](https://github.com/TiendaNube/nimbus-design-system/pull/64) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `none` and `underline` options in `textDecoration` property in sprinkle link. ([#66](https://github.com/TiendaNube/nimbus-design-system/pull/66) by [@juniorconquista](https://github.com/juniorconquista))
 
 ## 2022-12-07 `5.0.0`
 

--- a/packages/core/styles/src/packages/atomic/link/index.ts
+++ b/packages/core/styles/src/packages/atomic/link/index.ts
@@ -1,5 +1,7 @@
 import * as styles from "./link.style.css";
+import { linkSprinkle } from "./link.sprinkle.css";
 
 export const link = {
   classnames: { ...styles },
+  ...linkSprinkle,
 };

--- a/packages/core/styles/src/packages/atomic/link/link.sprinkle.css.ts
+++ b/packages/core/styles/src/packages/atomic/link/link.sprinkle.css.ts
@@ -1,0 +1,17 @@
+import { defineProperties, createSprinkles } from "@vanilla-extract/sprinkles";
+import { textDecorationProperties } from "../../../properties";
+
+const properties = {
+  textDecoration: textDecorationProperties,
+};
+
+const sprinkle = createSprinkles(
+  defineProperties({
+    properties,
+  })
+);
+
+export const linkSprinkle = {
+  sprinkle,
+  properties,
+};

--- a/packages/core/styles/src/packages/atomic/link/link.style.css.ts
+++ b/packages/core/styles/src/packages/atomic/link/link.style.css.ts
@@ -33,13 +33,6 @@ export const size = styleVariants({
   },
 });
 
-export const textDecoration = styleVariants({
-  underline: {
-    textDecoration: "underline",
-  },
-  none: {},
-});
-
 export const appearance = styleVariants({
   primary: [
     base,

--- a/packages/core/styles/src/properties/css.ts
+++ b/packages/core/styles/src/properties/css.ts
@@ -10,6 +10,7 @@ import {
   FlexWrap,
   JustifyContent,
   TextAlign,
+  TextDecoration,
 } from "../types";
 import { baseColors } from "./base";
 
@@ -74,6 +75,7 @@ export const textAlignProperties: TextAlign[] = [
   "center",
   "justify",
 ];
+export const textDecorationProperties: TextDecoration[] = ["none", "underline"];
 export const fontWeightProperties = {
   regular: varsThemeBase.fontWeight.regular,
   bold: varsThemeBase.fontWeight.bold,

--- a/packages/core/styles/src/types/index.ts
+++ b/packages/core/styles/src/types/index.ts
@@ -31,3 +31,4 @@ export type AlignItems =
   | "center"
   | "baseline";
 export type TextAlign = "left" | "right" | "center" | "justify";
+export type TextDecoration = "none" | "underline";

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This package is intended for internal use in generating builds of each design system package. It contains all the necessary settings and dependencies to optimize the creation of our builds.
 
+## 2022-12-15 `1.0.1`
+
+### 🐛 Bug fixes
+
+- Fixed bug in the `textDecoration` property where the `none` option was not applied when the link contained the `href` property. ([#64](https://github.com/TiendaNube/nimbus-design-system/pull/64) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2022-12-07 `1.0.0`
 
 ### 📚 3rd party library updates

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -6,7 +6,7 @@ This package is intended for internal use in generating builds of each design sy
 
 ### 🐛 Bug fixes
 
-- Fixed bug in the `textDecoration` property where the `none` option was not applied when the link contained the `href` property. ([#64](https://github.com/TiendaNube/nimbus-design-system/pull/64) by [@juniorconquista](https://github.com/juniorconquista))
+- Fixed bug in the `textDecoration` property where the `none` option was not applied when the link contained the `href` property. ([#66](https://github.com/TiendaNube/nimbus-design-system/pull/66) by [@juniorconquista](https://github.com/juniorconquista))
 
 ## 2022-12-07 `1.0.0`
 

--- a/packages/react/src/atomic/Link/CHANGELOG.md
+++ b/packages/react/src/atomic/Link/CHANGELOG.md
@@ -6,7 +6,7 @@ The Link component allows us to navigate to external addresses.
 
 ### 🐛 Bug fixes
 
-- Fixed bug in the `textDecoration` property where the `none` option was not applied when the link contained the `href` property. ([#64](https://github.com/TiendaNube/nimbus-design-system/pull/64) by [@juniorconquista](https://github.com/juniorconquista))
+- Fixed bug in the `textDecoration` property where the `none` option was not applied when the link contained the `href` property. ([#66](https://github.com/TiendaNube/nimbus-design-system/pull/66) by [@juniorconquista](https://github.com/juniorconquista))
 
 ## 2022-12-07 `2.1.0`
 

--- a/packages/react/src/atomic/Link/CHANGELOG.md
+++ b/packages/react/src/atomic/Link/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The Link component allows us to navigate to external addresses.
 
+## 2022-12-15 `2.1.1`
+
+### 🐛 Bug fixes
+
+- Fixed bug in the `textDecoration` property where the `none` option was not applied when the link contained the `href` property. ([#64](https://github.com/TiendaNube/nimbus-design-system/pull/64) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2022-12-07 `2.1.0`
 
 ### 🎉 New features

--- a/packages/react/src/atomic/Link/src/Link.tsx
+++ b/packages/react/src/atomic/Link/src/Link.tsx
@@ -18,7 +18,7 @@ const Link: React.FC<LinkProps> & LinkComponents = ({
     className={[
       link.classnames.appearance[appearance],
       link.classnames.size[size],
-      link.classnames.textDecoration[textDecoration],
+      link.sprinkle({ textDecoration }),
     ].join(" ")}
   >
     {children}

--- a/packages/react/src/atomic/Link/src/link.spec.tsx
+++ b/packages/react/src/atomic/Link/src/link.spec.tsx
@@ -38,13 +38,6 @@ describe("GIVEN <Link />", () => {
       ).toContain("appearance_neutral");
     });
 
-    it("THEN should correctly render without underline", () => {
-      makeSut({ textDecoration: "none", href: "#", children: "link" });
-      expect(
-        screen.getByRole("link", { name: "link" }).getAttribute("class")
-      ).toContain("textDecoration_none");
-    });
-
     it("THEN should correctly render with size caption", () => {
       makeSut({ size: "caption", href: "#", children: "link" });
       expect(
@@ -64,6 +57,20 @@ describe("GIVEN <Link />", () => {
       expect(
         screen.getByRole("link", { name: "link" }).getAttribute("class")
       ).toContain("size_highlight");
+    });
+
+    it("THEN should correctly render with textDecoration none", () => {
+      makeSut({ textDecoration: "none", href: "#", children: "link" });
+      expect(
+        screen.getByRole("link", { name: "link" }).getAttribute("class")
+      ).toContain("textDecoration_none");
+    });
+
+    it("THEN should correctly render with textDecoration underline", () => {
+      makeSut({ textDecoration: "underline", href: "#", children: "link" });
+      expect(
+        screen.getByRole("link", { name: "link" }).getAttribute("class")
+      ).toContain("textDecoration_underline");
     });
   });
 });

--- a/packages/react/src/atomic/Link/src/link.stories.tsx
+++ b/packages/react/src/atomic/Link/src/link.stories.tsx
@@ -33,6 +33,7 @@ const SkeletonTemplate: ComponentStory<typeof Link.Skeleton> = (args) => (
 export const base = Template.bind({});
 base.args = {
   children: "Link",
+  href: "mailto: hola@tiendanube.com",
 };
 
 export const icon = Template.bind({});

--- a/packages/react/src/atomic/Link/src/link.types.ts
+++ b/packages/react/src/atomic/Link/src/link.types.ts
@@ -1,4 +1,5 @@
 import { ReactNode, AnchorHTMLAttributes } from "react";
+import { link } from "@nimbus-ds/styles";
 import { LinkSkeleton } from "./components";
 
 export interface LinkComponents {
@@ -11,7 +12,7 @@ export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   /** Link appearance */
   appearance?: "primary" | "danger" | "neutral";
   /** Decoration for the link text */
-  textDecoration?: "underline" | "none";
+  textDecoration?: typeof link.properties.textDecoration[number];
   /** Size of the link text */
   size?: "caption" | "base" | "highlight";
 }


### PR DESCRIPTION
# [BUG] Link underlined when textDecoration "none" and href defined 

## Type

- [x] Bugfix 🐛
- [ ] New feature 🌈
- [ ] Change request 🤓
- [x] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

### `@nimbus-ds/styles`

#### 🎉 New features

- Added `none` and `underline` options in `textDecoration` property in sprinkle link. ([#66](https://github.com/TiendaNube/nimbus-design-system/pull/66) by [@juniorconquista](https://github.com/juniorconquista))

### `@nimbus-ds/link`

#### 🐛 Bug fixes

- Fixed bug in the `textDecoration` property where the `none` option was not applied when the link contained the `href` property. ([#66](https://github.com/TiendaNube/nimbus-design-system/pull/66) by [@juniorconquista](https://github.com/juniorconquista))

### `@nimbus-ds/components`

#### 🐛 Bug fixes

- Fixed bug in the `textDecoration` property where the `none` option was not applied when the link contained the `href` property. ([#66](https://github.com/TiendaNube/nimbus-design-system/pull/66) by [@juniorconquista](https://github.com/juniorconquista))

## Screenshots 🏞

## Related issues 🐛
