### PR TITLE
ECNIM-529

### DIFF
--- a/.yarn/versions/bf712393.yml
+++ b/.yarn/versions/bf712393.yml
@@ -1,0 +1,8 @@
+releases:
+  "@nimbus-ds/components": minor
+  "@nimbus-ds/modal": major
+  "@nimbus-ds/styles": minor
+
+declined:
+  - nimbus-design-system
+  - "@nimbus-ds/pagination"

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -39,6 +39,7 @@ const config: Config.InitialOptions = {
     // composites
     "@nimbus-ds/alert": "<rootDir>/packages/react/src/composite/Alert/src",
     "@nimbus-ds/card": "<rootDir>/packages/react/src/composite/Card/src",
+    "@nimbus-ds/modal": "<rootDir>/packages/react/src/composite/Modal/src",
     "@nimbus-ds/sidebar": "<rootDir>/packages/react/src/composite/Sidebar/src",
     "@nimbus-ds/tabs": "<rootDir>/packages/react/src/composite/Tabs/src",
     "@nimbus-ds/table": "<rootDir>/packages/react/src/composite/Table/src",

--- a/packages/core/styles/CHANGELOG.md
+++ b/packages/core/styles/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus Styles deprive all styles needed to build nimbus components.
 
+## 2023-02-01 `6.4.0`
+
+#### 🎉 New features
+
+- Added new style pack for modal component. [#77](https://github.com/TiendaNube/nimbus-design-system/pull/#77) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2023-01-27 `6.3.0`
 
 #### 🎉 New features

--- a/packages/core/styles/src/components/ThemeProvider/themeProvider.spec.tsx
+++ b/packages/core/styles/src/components/ThemeProvider/themeProvider.spec.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { ThemeProvider } from ".";
+import { ThemeProviderProps } from "./themeProvider.types";
+
+const makeSut = (props: ThemeProviderProps) => {
+  render(<ThemeProvider {...props} data-testid="theme-provider-element" />);
+};
+
+describe("GIVEN <ThemeProvider />", () => {
+  describe("WHEN rendered", () => {
+    it("THEN should render the submitted children", () => {
+      makeSut({ children: "My children" });
+      expect(screen.getByText("My children")).toBeDefined();
+    });
+  });
+
+  describe("THEN should correctly render the submitted theme", () => {
+    it("THEN should correctly render the padding default", () => {
+      makeSut({ children: "My children" });
+      expect(
+        screen.getByTestId("theme-provider-element").getAttribute("class")
+      ).toEqual("");
+    });
+
+    it("THEN should correctly render the padding base", () => {
+      makeSut({ children: "My children", theme: "base" });
+      expect(
+        screen.getByTestId("theme-provider-element").getAttribute("class")
+      ).toEqual("");
+    });
+
+    it("THEN should correctly render the padding dark", () => {
+      makeSut({ children: "My children", theme: "dark" });
+      expect(
+        screen.getByTestId("theme-provider-element").getAttribute("class")
+      ).toContain("dark");
+    });
+  });
+});

--- a/packages/core/styles/src/index.ts
+++ b/packages/core/styles/src/index.ts
@@ -31,6 +31,7 @@ export { textarea } from "./packages/atomic/textarea";
 
 export { alert } from "./packages/composite/alert";
 export { card } from "./packages/composite/card";
+export { modal } from "./packages/composite/modal";
 export { pagination } from "./packages/composite/pagination";
 export { sidebar } from "./packages/composite/sidebar";
 export { tabs } from "./packages/composite/tabs";
@@ -39,5 +40,6 @@ export { table } from "./packages/composite/table";
 export type { BoxSprinkle } from "./packages/atomic/box";
 export type { IconButtonSprinkle } from "./packages/atomic/iconButton";
 export type { StackSprinkle } from "./packages/atomic/stack";
+export type { ModalSprinkle } from "./packages/composite/modal";
 export type { SidebarSprinkle } from "./packages/composite/sidebar";
 export type { TableSprinkle } from "./packages/composite/table";

--- a/packages/core/styles/src/packages/composite/alert/alert.style.css.ts
+++ b/packages/core/styles/src/packages/composite/alert/alert.style.css.ts
@@ -82,7 +82,7 @@ export const content = vanillaStyle({
   fontFamily: varsThemeBase.fontFamily.centranube,
 });
 
-export const close = vanillaStyle({
+const close = vanillaStyle({
   appearance: "none",
   borderStyle: "solid",
   borderColor: "transparent",

--- a/packages/core/styles/src/packages/composite/modal/index.ts
+++ b/packages/core/styles/src/packages/composite/modal/index.ts
@@ -1,0 +1,9 @@
+import * as styles from "./modal.style.css";
+import { modalSprinkle } from "./modal.sprinkle.css";
+
+export const modal = {
+  classnames: { ...styles },
+  ...modalSprinkle,
+};
+
+export type { ModalSprinkle } from "./modal.sprinkle.types";

--- a/packages/core/styles/src/packages/composite/modal/modal.sprinkle.css.ts
+++ b/packages/core/styles/src/packages/composite/modal/modal.sprinkle.css.ts
@@ -1,0 +1,36 @@
+import {
+  createRainbowSprinkles,
+  defineProperties as defineRainbowProperties,
+} from "rainbow-sprinkles";
+import { paddingProperties } from "../../../properties";
+import { mediaQueries } from "../../../themes";
+
+const properties = {
+  padding: paddingProperties,
+};
+
+const defineProperties = defineRainbowProperties({
+  conditions: {
+    xs: {
+      "@media": mediaQueries.xs(),
+    },
+    md: {
+      "@media": mediaQueries.md(),
+    },
+    lg: {
+      "@media": mediaQueries.lg(),
+    },
+  },
+  defaultCondition: "xs",
+  dynamicProperties: {
+    maxWidth: true,
+    padding: paddingProperties,
+  },
+});
+
+const sprinkle = createRainbowSprinkles(defineProperties);
+
+export const modalSprinkle = {
+  sprinkle,
+  properties,
+};

--- a/packages/core/styles/src/packages/composite/modal/modal.sprinkle.types.ts
+++ b/packages/core/styles/src/packages/composite/modal/modal.sprinkle.types.ts
@@ -1,0 +1,11 @@
+import { Conditions } from "../../../types";
+import { modalSprinkle } from "./modal.sprinkle.css";
+
+const { properties: propertiesModal } = modalSprinkle;
+
+type PaddingProperties = keyof typeof propertiesModal.padding;
+
+export interface ModalSprinkle {
+  maxWidth?: string | Conditions<string>;
+  padding?: PaddingProperties | Conditions<PaddingProperties>;
+}

--- a/packages/core/styles/src/packages/composite/modal/modal.style.css.ts
+++ b/packages/core/styles/src/packages/composite/modal/modal.style.css.ts
@@ -1,0 +1,79 @@
+import { style } from "@vanilla-extract/css";
+
+import { varsThemeBase } from "../../../themes";
+
+export const overlay = style({
+  display: "flex",
+  height: "100vh",
+  width: "100vw",
+  justifyContent: "center",
+  alignItems: "center",
+  position: "fixed",
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+  backgroundColor: "rgba(0, 0, 0, 0.5)",
+  zIndex: 100,
+});
+
+export const container = style({
+  position: "relative",
+  display: "flex",
+  flexDirection: "column",
+  width: "100%",
+  minHeight: "3rem",
+  justifyContent: "center",
+  flexWrap: "nowrap",
+  height: "auto",
+
+  backgroundColor: varsThemeBase.colors.neutral.background,
+  borderRadius: varsThemeBase.spacing[2],
+  boxSizing: "border-box",
+  zIndex: 200,
+});
+
+export const close = style({
+  appearance: "none",
+  borderStyle: "solid",
+  borderColor: "transparent",
+  borderWidth: 1,
+  background: "transparent",
+  cursor: "pointer",
+  margin: 0,
+
+  position: "absolute",
+  top: 0,
+  right: 0,
+
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+
+  padding: varsThemeBase.spacing[4],
+  borderRadius: varsThemeBase.spacing[2],
+
+  ":focus": {
+    boxShadow: varsThemeBase.utils.focus,
+  },
+  ":hover": {
+    backgroundColor: varsThemeBase.colors.neutral.surfaceHighlight,
+  },
+  ":active": {
+    backgroundColor: varsThemeBase.colors.neutral.interactivePressed,
+  },
+});
+
+export const header = style({
+  marginBottom: "1.125rem",
+});
+
+export const body = style({
+  marginBottom: "1rem",
+});
+
+export const footer = style({
+  display: "flex",
+  gap: varsThemeBase.spacing[2],
+  justifyContent: "flex-end",
+});

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This package is intended for internal use in generating builds of each design system package. It contains all the necessary settings and dependencies to optimize the creation of our builds.
 
+## 2023-02-01 `2.3.0`
+
+### 🎉 New features
+
+- Added new composite `Modal` component. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2023-01-27 `2.2.0`
 
 ### 🎉 New features

--- a/packages/react/src/composite/Modal/CHANGELOG.md
+++ b/packages/react/src/composite/Modal/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+The Modal component allows us to call the user's attention to a floating box that can have text, actions or forms to perform tasks by changing the focus from the background. It is an intrusive component as it interrupts the user's operation to present a message or content.
+
+## 2023-01-22 `1.0.0`
+
+### 📚 3rd party library updates
+
+- Added `webpack@5.74.0`. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
+
+### 🎉 New features
+
+- Added `children`, `open`, `onDismiss`, `portalId` and `padding` properties to the Component. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
+- Added stories on Component. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
+- Created new `Modal.Header` subcomponent. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `children` and `title` properties to the Component `Modal.Header`. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
+- Created new `Modal.Body` subcomponent. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `children` and `padding` properties to the Component `Modal.Body`. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
+- Created new `Modal.Footer` subcomponent. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `children` properties to the Component `Modal.Footer`. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))

--- a/packages/react/src/composite/Modal/README.md
+++ b/packages/react/src/composite/Modal/README.md
@@ -1,0 +1,44 @@
+# `@nimbus-ds/modal`
+
+[![@nimbus-ds/modal](https://img.shields.io/npm/v/@nimbus-ds/modal?label=%40nimbus-ds%2Fmodal)](https://www.npmjs.com/package/@nimbus-ds/modal)
+
+The Modal component allows us to call the user's attention to a floating box that can have text, actions or forms to perform tasks by changing the focus from the background. It is an intrusive component as it interrupts the user's operation to present a message or content.
+
+## Installation
+
+```sh
+$ yarn add @nimbus-ds/modal
+# or
+$ npm install @nimbus-ds/modal
+```
+
+### Component Anatomy
+
+The component consists of a full-screen translucent background and a centered floating box with rounded corners and shadow with optional padding.
+
+## Guidelines
+
+We use the component to present dialogs or options to the user that must be completed before continuing the operation. They are intrusive as they completely interrupt browsing, but they should be used occasionally.
+
+Modal must present actions to the user. Actions must form part of the footer of the modal, and must be located on the right side.
+
+The Modal must be able to be closed using the X button in the header, clicking outside the container or pressing the ESC key on the keyboard.
+
+Avoid its use for very long forms or screens with many options.
+
+### Recommendations for use
+
+- Confirm deletion of an element.
+- Display options as filters in lists.
+- Confirm an action before moving on to another instance.
+
+### Related components
+
+- Popover - It is a floating element that can be used to present information or actions in a non-intrusive way.
+- Alert - It is a component that presents critical or sensitive information to the user in a non-intrusive way within the context of a screen.
+
+## Usage
+
+View docs [here](https://nimbus.nuvemshop.com.br/documentation/composite-components/modal).
+
+<img alt="Nimbus" style="margin-bottom: 30px;" src="https://tiendanube.github.io/design-system-nimbus/static/media/nimbus-logo.ab60bd79.png" height="30" />

--- a/packages/react/src/composite/Modal/package.json
+++ b/packages/react/src/composite/Modal/package.json
@@ -14,8 +14,8 @@
     "version": "yarn version"
   },
   "dependencies": {
-    "@nimbus-ds/icon": "workspace:^",
     "@floating-ui/react-dom-interactions": "^0.10.1",
+    "@nimbus-ds/icon": "workspace:^",
     "@tiendanube/icons": "^0.3.1"
   },
   "peerDependencies": {

--- a/packages/react/src/composite/Modal/package.json
+++ b/packages/react/src/composite/Modal/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@nimbus-ds/modal",
+  "version": "0.0.0",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "webpack",
+    "clean": "rm -rf dist",
+    "version": "yarn version"
+  },
+  "dependencies": {
+    "@nimbus-ds/icon": "workspace:^",
+    "@floating-ui/react-dom-interactions": "^0.10.1",
+    "@tiendanube/icons": "^0.3.1"
+  },
+  "peerDependencies": {
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0"
+  },
+  "homepage": "https://nimbus.nuvemshop.com.br/documentation",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TiendaNube/nimbus-design-system.git"
+  },
+  "bugs": {
+    "url": "https://github.com/TiendaNube/nimbus-design-system/issues"
+  },
+  "devDependencies": {
+    "@nimbus-ds/box": "workspace:^",
+    "@nimbus-ds/button": "workspace:^",
+    "@nimbus-ds/stack": "workspace:^",
+    "@nimbus-ds/text": "workspace:^",
+    "@nimbus-ds/title": "workspace:^",
+    "webpack": "^5.74.0"
+  }
+}

--- a/packages/react/src/composite/Modal/src/Modal.tsx
+++ b/packages/react/src/composite/Modal/src/Modal.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import {
+  useFloating,
+  useDismiss,
+  useRole,
+  useClick,
+  useInteractions,
+  useId,
+  FloatingFocusManager,
+  FloatingOverlay,
+  FloatingPortal,
+} from "@floating-ui/react-dom-interactions";
+import { CloseIcon } from "@tiendanube/icons";
+import { Icon } from "@nimbus-ds/icon";
+import { modal } from "@nimbus-ds/styles";
+
+import { ModalProps, ModalComponents } from "./modal.types";
+import { ModalBody, ModalFooter, ModalHeader } from "./components";
+
+const Modal: React.FC<ModalProps> & ModalComponents = ({
+  className: _className,
+  style: _style,
+  children,
+  padding = "base",
+  maxWidth = { xs: "100%", md: "500px" },
+  open,
+  portalId,
+  onDismiss,
+  ...rest
+}: ModalProps) => {
+  const { className, style, otherProps } = modal.sprinkle({
+    ...(rest as Parameters<typeof modal.sprinkle>[0]),
+    maxWidth,
+    padding,
+  });
+
+  const { context } = useFloating({
+    open,
+    onOpenChange: onDismiss,
+  });
+
+  const click = useClick(context);
+  const role = useRole(context);
+  const dismiss = useDismiss(context, { outsidePressEvent: "mousedown" });
+
+  const { getFloatingProps } = useInteractions([click, role, dismiss]);
+
+  const headingId = useId();
+  const descriptionId = useId();
+
+  return (
+    <FloatingPortal id={portalId || "nimbus-modal-floating"}>
+      {open && (
+        <FloatingOverlay className={modal.classnames.overlay} lockScroll>
+          <FloatingFocusManager context={context}>
+            <div
+              {...otherProps}
+              style={style}
+              className={[modal.classnames.container, className].join(" ")}
+              aria-labelledby={headingId}
+              aria-describedby={descriptionId}
+              {...getFloatingProps()}
+              {...rest}
+            >
+              {children}
+              {onDismiss && (
+                <button
+                  aria-label="Dismiss modal"
+                  className={modal.classnames.close}
+                  data-testid="dismiss-modal-button"
+                  type="button"
+                  onClick={() => onDismiss(!open)}
+                  tabIndex={0}
+                >
+                  <Icon color="neutral.textLow" source={<CloseIcon />} />
+                </button>
+              )}
+            </div>
+          </FloatingFocusManager>
+        </FloatingOverlay>
+      )}
+    </FloatingPortal>
+  );
+};
+
+Modal.Body = ModalBody;
+Modal.Footer = ModalFooter;
+Modal.Header = ModalHeader;
+Modal.displayName = "Modal";
+Modal.Body.displayName = "Modal.Body";
+Modal.Footer.displayName = "Modal.Footer";
+Modal.Header.displayName = "Modal.Header";
+
+export { Modal };

--- a/packages/react/src/composite/Modal/src/components/ModalBody/ModalBody.tsx
+++ b/packages/react/src/composite/Modal/src/components/ModalBody/ModalBody.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { modal } from "@nimbus-ds/styles";
+
+import { ModalBodyProps } from "./modalBody.types";
+
+const ModalBody: React.FC<ModalBodyProps> = ({
+  className: _className,
+  style: _style,
+  padding = "none",
+  children,
+  ...rest
+}) => {
+  const { className, style, otherProps } = modal.sprinkle({
+    ...(rest as Parameters<typeof modal.sprinkle>[0]),
+    padding,
+  });
+
+  return (
+    <div
+      {...otherProps}
+      style={style}
+      className={[modal.classnames.body, className].join(" ")}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};
+
+export { ModalBody };

--- a/packages/react/src/composite/Modal/src/components/ModalBody/index.ts
+++ b/packages/react/src/composite/Modal/src/components/ModalBody/index.ts
@@ -1,0 +1,4 @@
+import { ModalBody } from "./ModalBody";
+
+export { ModalBody } from "./ModalBody";
+export default ModalBody;

--- a/packages/react/src/composite/Modal/src/components/ModalBody/modalBody.spec.tsx
+++ b/packages/react/src/composite/Modal/src/components/ModalBody/modalBody.spec.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { ModalBody } from "./ModalBody";
+import { ModalBodyProps } from "./modalBody.types";
+
+const makeSut = (props: ModalBodyProps) => {
+  render(<ModalBody {...props} data-testid="body-element" />);
+};
+
+describe("GIVEN <Modal.Body />", () => {
+  describe("WHEN rendered", () => {
+    it("THEN should render the submitted content", () => {
+      makeSut({ children: "My content" });
+      expect(screen.getByText("My content")).toBeDefined();
+    });
+  });
+
+  describe("THEN should correctly render the submitted padding", () => {
+    it("THEN should correctly render the padding default", () => {
+      makeSut({ children: "My content" });
+      expect(screen.getByTestId("body-element").getAttribute("style")).toMatch(
+        /--padding-xs__\w{0,9}: 0;/
+      );
+    });
+
+    it("AND should correctly render the padding none", () => {
+      makeSut({ padding: "none", children: "My content" });
+      expect(screen.getByTestId("body-element").getAttribute("style")).toMatch(
+        /--padding-xs__\w{0,9}: 0;/
+      );
+    });
+
+    it("AND should correctly render the padding base", () => {
+      makeSut({ padding: "base", children: "My content" });
+      expect(screen.getByTestId("body-element").getAttribute("style")).toMatch(
+        /--padding-xs__\w{0,9}: var\(--spacing-4__\w{0,9}\);/
+      );
+    });
+
+    it("AND should correctly render the padding small", () => {
+      makeSut({ padding: "small", children: "My content" });
+      expect(screen.getByTestId("body-element").getAttribute("style")).toMatch(
+        /--padding-xs__\w{0,9}: var\(--spacing-2__\w{0,9}\);/
+      );
+    });
+  });
+});

--- a/packages/react/src/composite/Modal/src/components/ModalBody/modalBody.types.ts
+++ b/packages/react/src/composite/Modal/src/components/ModalBody/modalBody.types.ts
@@ -1,0 +1,9 @@
+import { HTMLAttributes, ReactNode } from "react";
+import { card } from "@nimbus-ds/styles";
+
+export interface ModalBodyProps extends HTMLAttributes<HTMLElement> {
+  /** Body content */
+  children: ReactNode;
+  /** Card padding */
+  padding?: keyof typeof card.properties.padding;
+}

--- a/packages/react/src/composite/Modal/src/components/ModalFooter/ModalFooter.tsx
+++ b/packages/react/src/composite/Modal/src/components/ModalFooter/ModalFooter.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { modal } from "@nimbus-ds/styles";
+
+import { ModalFooterProps } from "./modalFooter.types";
+
+const ModalFooter: React.FC<ModalFooterProps> = ({
+  className: _className,
+  style: _style,
+  children,
+  ...rest
+}) => (
+  <div className={modal.classnames.footer} {...rest}>
+    {children}
+  </div>
+);
+
+export { ModalFooter };

--- a/packages/react/src/composite/Modal/src/components/ModalFooter/index.ts
+++ b/packages/react/src/composite/Modal/src/components/ModalFooter/index.ts
@@ -1,0 +1,4 @@
+import { ModalFooter } from "./ModalFooter";
+
+export { ModalFooter } from "./ModalFooter";
+export default ModalFooter;

--- a/packages/react/src/composite/Modal/src/components/ModalFooter/modalFooter.spec.tsx
+++ b/packages/react/src/composite/Modal/src/components/ModalFooter/modalFooter.spec.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { ModalFooter } from "./ModalFooter";
+import { ModalFooterProps } from "./modalFooter.types";
+
+const makeSut = (props: ModalFooterProps) => {
+  render(<ModalFooter {...props} data-testid="footer-element" />);
+};
+
+describe("GIVEN <Modal.Footer />", () => {
+  describe("WHEN rendered", () => {
+    it("THEN should render the submitted content", () => {
+      makeSut({ children: "My content" });
+      expect(screen.getByText("My content")).toBeDefined();
+    });
+  });
+});

--- a/packages/react/src/composite/Modal/src/components/ModalFooter/modalFooter.types.ts
+++ b/packages/react/src/composite/Modal/src/components/ModalFooter/modalFooter.types.ts
@@ -1,0 +1,6 @@
+import { HTMLAttributes, ReactNode } from "react";
+
+export interface ModalFooterProps extends HTMLAttributes<HTMLElement> {
+  /** Footer content */
+  children: ReactNode;
+}

--- a/packages/react/src/composite/Modal/src/components/ModalHeader/ModalHeader.tsx
+++ b/packages/react/src/composite/Modal/src/components/ModalHeader/ModalHeader.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Title } from "@nimbus-ds/title";
+import { modal } from "@nimbus-ds/styles";
+
+import { ModalHeaderProps } from "./modalHeader.types";
+
+const ModalHeader: React.FC<ModalHeaderProps> = ({
+  className: _className,
+  style: _style,
+  title,
+  children,
+  ...rest
+}) => (
+  <div {...rest} className={modal.classnames.header}>
+    {title && (
+      <Title data-testid="header-title" as="h3">
+        {title}
+      </Title>
+    )}
+    {children}
+  </div>
+);
+
+export { ModalHeader };

--- a/packages/react/src/composite/Modal/src/components/ModalHeader/index.ts
+++ b/packages/react/src/composite/Modal/src/components/ModalHeader/index.ts
@@ -1,0 +1,4 @@
+import { ModalHeader } from "./ModalHeader";
+
+export { ModalHeader } from "./ModalHeader";
+export default ModalHeader;

--- a/packages/react/src/composite/Modal/src/components/ModalHeader/modalHeader.spec.tsx
+++ b/packages/react/src/composite/Modal/src/components/ModalHeader/modalHeader.spec.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { ModalHeader } from "./ModalHeader";
+import { ModalHeaderProps } from "./modalHeader.types";
+
+const makeSut = (props?: ModalHeaderProps) => {
+  render(<ModalHeader {...props} data-testid="header-element" />);
+};
+
+describe("GIVEN <Modal.Header />", () => {
+  describe("WHEN rendered", () => {
+    it("THEN should render the submitted title", () => {
+      makeSut({ title: "My Title" });
+      expect(screen.getByText("My Title")).toBeDefined();
+      expect(screen.getByTestId("header-title")).toBeDefined();
+    });
+    it("THEN should not render the submitted title", () => {
+      makeSut();
+      expect(screen.queryByTestId("header-title")).toBeNull();
+    });
+  });
+});

--- a/packages/react/src/composite/Modal/src/components/ModalHeader/modalHeader.types.ts
+++ b/packages/react/src/composite/Modal/src/components/ModalHeader/modalHeader.types.ts
@@ -1,0 +1,8 @@
+import { HTMLAttributes, ReactNode } from "react";
+
+export interface ModalHeaderProps extends HTMLAttributes<HTMLElement> {
+  /** Header content */
+  children?: ReactNode;
+  /** Header title */
+  title?: string;
+}

--- a/packages/react/src/composite/Modal/src/components/index.ts
+++ b/packages/react/src/composite/Modal/src/components/index.ts
@@ -1,0 +1,3 @@
+export * from "./ModalBody";
+export * from "./ModalFooter";
+export * from "./ModalHeader";

--- a/packages/react/src/composite/Modal/src/index.ts
+++ b/packages/react/src/composite/Modal/src/index.ts
@@ -1,0 +1,5 @@
+import { Modal } from "./Modal";
+
+export { Modal } from "./Modal";
+export type { ModalProps } from "./modal.types";
+export default Modal;

--- a/packages/react/src/composite/Modal/src/modal.spec.tsx
+++ b/packages/react/src/composite/Modal/src/modal.spec.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { Modal } from "./Modal";
+import { ModalProps } from "./modal.types";
+
+const mockedOnDismiss = jest.fn();
+
+const makeSut = (rest: Pick<ModalProps, "children" | "padding">) => {
+  render(
+    <Modal
+      {...rest}
+      onDismiss={mockedOnDismiss}
+      open
+      data-testid="modal-element"
+    />
+  );
+};
+
+describe("GIVEN <Modal />", () => {
+  describe("WHEN rendered", () => {
+    it("THEN should correctly render the submitted content", () => {
+      makeSut({ children: <div>My content</div> });
+      expect(screen.getByText("My content")).toBeDefined();
+    });
+
+    it("AND should correctly call the onDismiss function when closing the modal", () => {
+      makeSut({ children: <div>My content</div> });
+      fireEvent.click(screen.getByTestId("dismiss-modal-button"));
+      expect(mockedOnDismiss).toBeCalledWith(false);
+    });
+  });
+
+  describe("THEN should correctly render the submitted padding", () => {
+    it("THEN should correctly render the padding default", () => {
+      makeSut({ children: "My content" });
+      expect(screen.getByTestId("modal-element").getAttribute("style")).toMatch(
+        /--padding-xs__\w{0,9}: var\(--spacing-4__\w{0,9}\);/
+      );
+    });
+
+    it("AND should correctly render the padding none", () => {
+      makeSut({ padding: "none", children: "My content" });
+      expect(screen.getByTestId("modal-element").getAttribute("style")).toMatch(
+        /--padding-xs__\w{0,9}: 0;/
+      );
+    });
+
+    it("AND should correctly render the padding base", () => {
+      makeSut({ padding: "base", children: "My content" });
+      expect(screen.getByTestId("modal-element").getAttribute("style")).toMatch(
+        /--padding-xs__\w{0,9}: var\(--spacing-4__\w{0,9}\);/
+      );
+    });
+
+    it("AND should correctly render the padding small", () => {
+      makeSut({ padding: "small", children: "My content" });
+      expect(screen.getByTestId("modal-element").getAttribute("style")).toMatch(
+        /--padding-xs__\w{0,9}: var\(--spacing-2__\w{0,9}\);/
+      );
+    });
+  });
+});

--- a/packages/react/src/composite/Modal/src/modal.stories.tsx
+++ b/packages/react/src/composite/Modal/src/modal.stories.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { withA11y } from "@storybook/addon-a11y";
+// eslint-disable-next-line
+import { useArgs } from "@storybook/client-api";
+import { modal } from "@nimbus-ds/styles";
+import { Text } from "@nimbus-ds/text";
+import { Button } from "@nimbus-ds/button";
+import { Box } from "@nimbus-ds/box";
+import { Stack } from "@nimbus-ds/stack";
+import { Title } from "@nimbus-ds/title";
+
+import { Modal } from "./Modal";
+
+export default {
+  title: "Composite/Modal",
+  component: Modal,
+  subcomponents: {
+    "Modal.Header": Modal.Header,
+    "Modal.Body": Modal.Body,
+    "Modal.Footer": Modal.Footer,
+  },
+  parameters: {
+    withA11y: { decorators: [withA11y] },
+  },
+  argTypes: {
+    children: { control: { disable: true } },
+    padding: { options: Object.keys(modal.properties.padding) },
+  },
+} as ComponentMeta<typeof Modal>;
+
+const Template: ComponentStory<typeof Modal> = (args) => {
+  const [{ open }, updateArgs] = useArgs();
+  const handleClose = () => updateArgs({ open: !open });
+  return (
+    <>
+      <Button onClick={handleClose}>Open</Button>
+      <Modal {...args} open={open} onDismiss={handleClose} />
+    </>
+  );
+};
+
+export const base = Template.bind({});
+base.args = {
+  children: (
+    <>
+      <Modal.Header title="Title" />
+      <Modal.Body>
+        <Text textAlign="left" fontSize="base" lineHeight="base">
+          Arcu condimentum enim at tristique aenean in. Fringilla urna, nec
+          dignissim malesuada lobortis faucibus volutpat. Purus tincidunt
+          adipiscing id felis, tincidunt nunc nibh urna ac.
+        </Text>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button appearance="neutral">Button</Button>
+        <Button appearance="primary">Button</Button>
+      </Modal.Footer>
+    </>
+  ),
+};
+
+export const WithHeader = Template.bind({});
+WithHeader.args = {
+  children: (
+    <>
+      <Modal.Header title="Title" />
+      <Modal.Body>
+        <Box
+          borderStyle="dashed"
+          padding="2"
+          borderWidth="1px"
+          borderColor="neutral.interactive"
+        >
+          <Text textAlign="center" fontSize="base">
+            Replace me with your content
+          </Text>
+        </Box>
+      </Modal.Body>
+    </>
+  ),
+};
+
+export const WithFooterAndHeader = Template.bind({});
+WithFooterAndHeader.args = {
+  children: (
+    <>
+      <Modal.Header title="Title" />
+      <Modal.Body>
+        <Box
+          borderStyle="dashed"
+          padding="2"
+          borderWidth="1px"
+          borderColor="neutral.interactive"
+        >
+          <Text textAlign="center" fontSize="base">
+            Replace me with your content
+          </Text>
+        </Box>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button appearance="primary">Button</Button>
+      </Modal.Footer>
+    </>
+  ),
+};
+
+export const content = Template.bind({});
+content.args = {
+  padding: "none",
+  children: (
+    <Text textAlign="center" fontSize="base" lineHeight="base">
+      Replace me with your content
+    </Text>
+  ),
+};
+
+export const skeleton = Template.bind({});
+skeleton.args = {
+  children: (
+    <>
+      <Modal.Header>
+        <Stack
+          display="flex"
+          justifyContent="space-between"
+          alignItems="center"
+          gap="4"
+        >
+          <Title.Skeleton as="h3" width="80%" />
+        </Stack>
+      </Modal.Header>
+      <Modal.Body>
+        <Text.Skeleton width="100%" />
+      </Modal.Body>
+      <Modal.Footer>
+        <Button.Skeleton />
+        <Button.Skeleton />
+      </Modal.Footer>
+    </>
+  ),
+};

--- a/packages/react/src/composite/Modal/src/modal.types.ts
+++ b/packages/react/src/composite/Modal/src/modal.types.ts
@@ -1,0 +1,24 @@
+import { HTMLAttributes, ReactNode } from "react";
+import { modal, ModalSprinkle } from "@nimbus-ds/styles";
+import { ModalBody, ModalFooter, ModalHeader } from "./components";
+
+type ModalExtends = ModalSprinkle & HTMLAttributes<HTMLDivElement>;
+
+export interface ModalComponents {
+  Body: typeof ModalBody;
+  Footer: typeof ModalFooter;
+  Header: typeof ModalHeader;
+}
+
+export interface ModalProps extends ModalExtends {
+  /** Modal content */
+  children: ReactNode;
+  /** Control open Modal */
+  open: boolean;
+  /** Function to be passed on actioning the dismiss button */
+  onDismiss: (open: boolean) => void;
+  /** Modal ID */
+  portalId?: string;
+  /** Modal padding */
+  padding?: keyof typeof modal.properties.padding;
+}

--- a/packages/react/src/composite/Modal/tsconfig.json
+++ b/packages/react/src/composite/Modal/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "include": ["./src"],
+  "exclude": ["src/**/*.spec.tsx"]
+}

--- a/packages/react/src/composite/Modal/webpack.config.ts
+++ b/packages/react/src/composite/Modal/webpack.config.ts
@@ -1,0 +1,11 @@
+import path from "path";
+import { configuration } from "@nimbus-ds/webpack/src";
+
+const config = {
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    library: "@nimbus-ds/modal",
+  },
+};
+
+export default () => configuration.getConfiguration(config);

--- a/packages/react/src/composite/Pagination/src/hooks/usePagination/usePagination.spec.ts
+++ b/packages/react/src/composite/Pagination/src/hooks/usePagination/usePagination.spec.ts
@@ -39,5 +39,13 @@ describe("GIVEN usePagination", () => {
       });
       expect(result.current).toEqual([1, "...", 4, 5, 6, "...", 20]);
     });
+
+    it("AND should render the default return", () => {
+      const { result } = makeSut({
+        activePage: NaN,
+        pageCount: 20,
+      });
+      expect(result.current).toEqual([]);
+    });
   });
 });

--- a/packages/react/src/composite/Pagination/src/hooks/usePagination/usePagination.ts
+++ b/packages/react/src/composite/Pagination/src/hooks/usePagination/usePagination.ts
@@ -70,8 +70,8 @@ export const usePagination = ({
       const middleRange = range(leftSiblingIndex, rightSiblingIndex);
       return [firstPageIndex, DOTS, ...middleRange, DOTS, lastPageIndex];
     }
+
     return [];
-    // Our implementation logic will go here
   }, [pageCount, siblingCount, activePage]);
 
   return paginationRange;

--- a/packages/react/src/composite/Table/src/components/TableBody/tableBody.spec.tsx
+++ b/packages/react/src/composite/Table/src/components/TableBody/tableBody.spec.tsx
@@ -5,7 +5,11 @@ import { TableBody } from "./TableBody";
 import { TableBodyProps } from "./tableBody.types";
 
 const makeSut = (rest: TableBodyProps) => {
-  render(<TableBody {...rest} data-testid="table-element" />);
+  render(
+    <table>
+      <TableBody {...rest} data-testid="table-element" />
+    </table>
+  );
 };
 
 describe("GIVEN <TableBody />", () => {

--- a/packages/react/src/composite/Table/src/components/TableCell/tableCell.spec.tsx
+++ b/packages/react/src/composite/Table/src/components/TableCell/tableCell.spec.tsx
@@ -11,9 +11,15 @@ const makeSut = (
   children = cellContent
 ) => {
   render(
-    <TableCell {...rest} data-testid="table-element">
-      {children}
-    </TableCell>
+    <table>
+      <tbody>
+        <tr>
+          <TableCell {...rest} data-testid="table-element">
+            {children}
+          </TableCell>
+        </tr>
+      </tbody>
+    </table>
   );
 };
 

--- a/packages/react/src/composite/Table/src/components/TableHead/tableHead.spec.tsx
+++ b/packages/react/src/composite/Table/src/components/TableHead/tableHead.spec.tsx
@@ -5,7 +5,11 @@ import { TableHead } from "./TableHead";
 import { TableHeadProps } from "./tableHead.types";
 
 const makeSut = (rest: TableHeadProps) => {
-  render(<TableHead {...rest} data-testid="table-element" />);
+  render(
+    <table>
+      <TableHead {...rest} data-testid="table-element" />
+    </table>
+  );
 };
 
 describe("GIVEN <TableHead />", () => {

--- a/packages/react/src/composite/Table/src/components/TableRow/tableRow.spec.tsx
+++ b/packages/react/src/composite/Table/src/components/TableRow/tableRow.spec.tsx
@@ -13,9 +13,13 @@ const makeSut = (
   children = cellChildren
 ) => {
   render(
-    <TableRow {...rest} data-testid="table-element">
-      {children}
-    </TableRow>
+    <table>
+      <tbody>
+        <TableRow {...rest} data-testid="table-element">
+          {children}
+        </TableRow>
+      </tbody>
+    </table>
   );
 };
 

--- a/packages/react/src/composite/Table/src/table.spec.tsx
+++ b/packages/react/src/composite/Table/src/table.spec.tsx
@@ -11,7 +11,15 @@ const makeSut = (rest: TableProps) => {
 describe("GIVEN <Table />", () => {
   describe("WHEN rendered", () => {
     it("THEN should correctly render the submitted content", () => {
-      makeSut({ children: <div>My content</div> });
+      makeSut({
+        children: (
+          <tbody>
+            <tr>
+              <td>My content</td>
+            </tr>
+          </tbody>
+        ),
+      });
       expect(screen.getByText("My content")).toBeDefined();
     });
   });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -28,6 +28,7 @@ export * from "@nimbus-ds/tooltip";
 // composite
 export * from "@nimbus-ds/alert";
 export * from "@nimbus-ds/card";
+export * from "@nimbus-ds/modal";
 export * from "@nimbus-ds/sidebar";
 export * from "@nimbus-ds/tabs";
 export * from "@nimbus-ds/table";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,6 +70,7 @@
       "@nimbus-ds/tooltip": ["./packages/react/src/atomic/Tooltip/src"],
       "@nimbus-ds/alert": ["./packages/react/src/composite/Alert/src"],
       "@nimbus-ds/card": ["./packages/react/src/composite/Card/src"],
+      "@nimbus-ds/modal": ["./packages/react/src/composite/Modal/src"],
       "@nimbus-ds/sidebar": ["./packages/react/src/composite/Sidebar/src"],
       "@nimbus-ds/tabs": ["./packages/react/src/composite/Tabs/src"],
       "@nimbus-ds/table": ["./packages/react/src/composite/Table/src"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3144,6 +3144,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@nimbus-ds/modal@workspace:packages/react/src/composite/Modal":
+  version: 0.0.0-use.local
+  resolution: "@nimbus-ds/modal@workspace:packages/react/src/composite/Modal"
+  dependencies:
+    "@nimbus-ds/box": "workspace:^"
+    "@nimbus-ds/button": "workspace:^"
+    "@nimbus-ds/stack": "workspace:^"
+    "@nimbus-ds/tag": "workspace:^"
+    "@nimbus-ds/text": "workspace:^"
+    webpack: ^5.74.0
+  peerDependencies:
+    "@nimbus-ds/title": "workspace:^"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  languageName: unknown
+  linkType: soft
+
 "@nimbus-ds/pagination@workspace:packages/react/src/composite/Pagination":
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/pagination@workspace:packages/react/src/composite/Pagination"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,14 +3148,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/modal@workspace:packages/react/src/composite/Modal"
   dependencies:
+    "@floating-ui/react-dom-interactions": ^0.10.1
     "@nimbus-ds/box": "workspace:^"
     "@nimbus-ds/button": "workspace:^"
+    "@nimbus-ds/icon": "workspace:^"
     "@nimbus-ds/stack": "workspace:^"
-    "@nimbus-ds/tag": "workspace:^"
     "@nimbus-ds/text": "workspace:^"
+    "@nimbus-ds/title": "workspace:^"
+    "@tiendanube/icons": ^0.3.1
     webpack: ^5.74.0
   peerDependencies:
-    "@nimbus-ds/title": "workspace:^"
     react: ^16.8 || ^17.0 || ^18.0
     react-dom: ^16.8 || ^17.0 || ^18.0
   languageName: unknown


### PR DESCRIPTION
## Type

- [ ] Bugfix 🐛
- [X] New feature 🌈
- [ ] Change request 🤓
- [X] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

## `@nimbus-ds/styles`

### 🎉 New features

- Added new style pack for modal component. [#77](https://github.com/TiendaNube/nimbus-design-system/pull/#77) by [@juniorconquista](https://github.com/juniorconquista))

## `@nimbus-ds/components`

### 🎉 New features

- Added new composite `Modal` component. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))

## `@nimbus-ds/modal`

### 📚 3rd party library updates

- Added `webpack@5.74.0`. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))

### 🎉 New features

- Added `children`, `open`, `onDismiss`, `portalId` and `padding` properties to the Component. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
- Added stories on Component. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
- Created new `Modal.Header` subcomponent. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
- Added `children` and `title` properties to the Component `Modal.Header`. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
- Created new `Modal.Body` subcomponent. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
- Added `children` and `padding` properties to the Component `Modal.Body`. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
- Created new `Modal.Footer` subcomponent. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))
- Added `children` properties to the Component `Modal.Footer`. ([#77](https://github.com/TiendaNube/nimbus-design-system/pull/77) by [@juniorconquista](https://github.com/juniorconquista))

## Screenshots 🏞

## Related issues 🐛
