### PR TITLE
ECNIM-736

### DIFF
--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -1,16 +1,40 @@
 import path from "path";
 
+export const argTypesConvert = (properties: any) =>
+  Object.keys(properties).reduce(
+    (
+      prev: { [key: string]: { control: string; options: string[] } },
+      curr: string
+    ) => {
+      let options = [];
+      if (Array.isArray(properties[curr])) {
+        options = properties[curr];
+      } else if (typeof properties[curr] === "object") {
+        options = Object.keys(properties[curr]);
+      }
+      prev[curr] = {
+        control: options?.length > 6 ? "select" : "radio",
+        options,
+      };
+      return prev;
+    },
+    {}
+  );
+
 export const convertTsConfigPathsToWebpackAliases = () => {
   const rootDir = path.resolve(__dirname, "../");
   const tsconfig = require("../tsconfig.json");
   const tsconfigPaths = Object.entries(tsconfig.compilerOptions.paths);
 
-  const paths = tsconfigPaths.reduce((aliases, [realPath, mappedPath]: any) => {
-    const packageName = mappedPath[0].split("/")[5];
-    const alias = `${mappedPath[0]}/${packageName}.tsx`;
-    aliases[realPath] = path.join(rootDir, alias);
-    return aliases;
-  }, {});
+  const paths = tsconfigPaths.reduce(
+    (aliases: any, [realPath, mappedPath]: any) => {
+      const packageName = mappedPath[0].split("/")[5];
+      const alias = `${mappedPath[0]}/${packageName}.tsx`;
+      aliases[realPath] = path.join(rootDir, alias);
+      return aliases;
+    },
+    {}
+  );
 
   paths["@nimbus-ds/tokens"] = path.join(rootDir, "packages/core/tokens");
   paths["@nimbus-ds/icons"] = path.join(rootDir, "packages/icons");
@@ -26,5 +50,6 @@ export const convertTsConfigPathsToWebpackAliases = () => {
     rootDir,
     "packages/core/typings/src/index.ts"
   );
+  paths[".storybook"] = path.join(rootDir, ".storybook");
   return paths;
 };

--- a/.yarn/versions/c08eb267.yml
+++ b/.yarn/versions/c08eb267.yml
@@ -1,0 +1,21 @@
+releases:
+  "@nimbus-ds/card": minor
+  "@nimbus-ds/components": minor
+  "@nimbus-ds/modal": minor
+  "@nimbus-ds/styles": minor
+  "@nimbus-ds/text": minor
+  "@nimbus-ds/tokens": patch
+
+declined:
+  - nimbus-design-system
+  - "@nimbus-ds/badge"
+  - "@nimbus-ds/checkbox"
+  - "@nimbus-ds/chip"
+  - "@nimbus-ds/file-uploader"
+  - "@nimbus-ds/radio"
+  - "@nimbus-ds/tag"
+  - "@nimbus-ds/toast"
+  - "@nimbus-ds/toggle"
+  - "@nimbus-ds/accordion"
+  - "@nimbus-ds/sidebar"
+  - "@nimbus-ds/tabs"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@vanilla-extract/webpack-plugin": "^2.2.0",
     "babel-jest": "^28.1.3",
     "babel-loader": "^8.2.5",
+    "babel-plugin-module-resolver": "^5.0.0",
     "child_process": "^1.0.2",
     "dts-bundle-generator": "^7.1.0",
     "eslint": "^8.19.0",

--- a/packages/core/styles/CHANGELOG.md
+++ b/packages/core/styles/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Nimbus Styles deprive all styles needed to build nimbus components.
 
+## 2023-06-13 `9.1.0`
+
+#### 🎉 New features
+
+- Added new wordbreak prop in Text component style pack. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
+
+#### 💡 Others
+
+- Spacing adjustments in Card, Modal and Sidebar component style packs. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2023-05-18 `9.0.0`
 
 #### 🛠 Breaking changes

--- a/packages/core/styles/src/packages/atomic/text/nimbus-text.css.ts
+++ b/packages/core/styles/src/packages/atomic/text/nimbus-text.css.ts
@@ -10,6 +10,7 @@ import {
   fontWeightProperties,
   lineHeightProperties,
   textAlignProperties,
+  wordBreakProperties,
 } from "../../../properties";
 import { mediaQueries, varsThemeBase } from "../../../themes";
 
@@ -76,6 +77,7 @@ const properties = {
   lineHeight: lineHeightProperties,
   fontWeight: fontWeightProperties,
   fontSize: fontSizeProperties,
+  wordBreak: wordBreakProperties,
 };
 
 const defineProperties = defineRainbowProperties({

--- a/packages/core/styles/src/packages/atomic/text/nimbus-text.types.ts
+++ b/packages/core/styles/src/packages/atomic/text/nimbus-text.types.ts
@@ -1,4 +1,4 @@
-import { Conditions, TextAlign } from "../../../types";
+import { Conditions, TextAlign, WordBreak } from "../../../types";
 import { textSprinkle } from "./nimbus-text.css";
 
 const { properties: propertiesText } = textSprinkle;
@@ -48,4 +48,8 @@ export interface TextSprinkle {
    * The amount of lines at which the text will be trimmed, showing an ellipsis when overflowed.
    */
   WebkitLineClamp?: number | TextConditions<number>;
+  /**
+   * The amount of lines at which the text will be trimmed, showing an ellipsis when overflowed.
+   */
+  wordBreak?: WordBreak | TextConditions<WordBreak>;
 }

--- a/packages/core/styles/src/packages/composite/card/index.ts
+++ b/packages/core/styles/src/packages/composite/card/index.ts
@@ -1,6 +1,17 @@
-import { styles, cardSprinkle } from "./nimbus-card.css";
+import {
+  styles,
+  cardSprinkle,
+  cardHeaderSprinkle,
+  cardBodySprinkle,
+  cardFooterSprinkle,
+} from "./nimbus-card.css";
 
 export const card = {
-  classnames: { ...styles },
   ...cardSprinkle,
+  classnames: { ...styles },
+  subComponents: {
+    header: cardHeaderSprinkle,
+    body: cardBodySprinkle,
+    footer: cardFooterSprinkle,
+  },
 };

--- a/packages/core/styles/src/packages/composite/card/nimbus-card.css.ts
+++ b/packages/core/styles/src/packages/composite/card/nimbus-card.css.ts
@@ -30,7 +30,6 @@ const container__footer = style({
 
 export const styles = {
   container,
-
   container__footer,
 };
 
@@ -57,18 +56,67 @@ const cardBackgroundColorProperties = {
     backgroundColorProperties["neutral-surfaceHighlight"],
 };
 
-const properties = {
+const cardProperties = {
   backgroundColor: cardBackgroundColorProperties,
   padding: paddingProperties,
 };
 
-const sprinkle = createSprinkles(
-  defineProperties({
-    properties,
-  })
-);
-
 export const cardSprinkle = {
-  sprinkle,
-  properties,
+  sprinkle: createSprinkles(
+    defineProperties({
+      properties: cardProperties,
+    })
+  ),
+  properties: cardProperties,
+};
+
+const cardHeaderProperties = {
+  padding: {
+    base: `${varsThemeBase.spacing[4]} ${varsThemeBase.spacing[4]} 0 ${varsThemeBase.spacing[4]}`,
+    small: `${varsThemeBase.spacing[2]} ${varsThemeBase.spacing[2]} 0 ${varsThemeBase.spacing[2]}`,
+    none: "0",
+  },
+};
+
+export const cardHeaderSprinkle = {
+  sprinkle: createSprinkles(
+    defineProperties({
+      properties: cardHeaderProperties,
+    })
+  ),
+  properties: cardHeaderProperties,
+};
+
+const cardBodyProperties = {
+  padding: {
+    base: `0 ${varsThemeBase.spacing[4]}`,
+    small: `0 ${varsThemeBase.spacing[2]}`,
+    none: "0",
+  },
+};
+
+export const cardBodySprinkle = {
+  sprinkle: createSprinkles(
+    defineProperties({
+      properties: cardBodyProperties,
+    })
+  ),
+  properties: cardBodyProperties,
+};
+
+const cardFooterProperties = {
+  padding: {
+    base: `0 ${varsThemeBase.spacing[4]} ${varsThemeBase.spacing[4]} ${varsThemeBase.spacing[4]}`,
+    small: `0 ${varsThemeBase.spacing[2]} ${varsThemeBase.spacing[2]} ${varsThemeBase.spacing[2]}`,
+    none: "0",
+  },
+};
+
+export const cardFooterSprinkle = {
+  sprinkle: createSprinkles(
+    defineProperties({
+      properties: cardFooterProperties,
+    })
+  ),
+  properties: cardFooterProperties,
 };

--- a/packages/core/styles/src/packages/composite/modal/index.ts
+++ b/packages/core/styles/src/packages/composite/modal/index.ts
@@ -1,8 +1,19 @@
-import { styles, modalSprinkle } from "./nimbus-modal.css";
+import {
+  styles,
+  modalSprinkle,
+  modalHeaderSprinkle,
+  modalBodySprinkle,
+  modalFooterSprinkle,
+} from "./nimbus-modal.css";
 
 export const modal = {
-  classnames: { ...styles },
   ...modalSprinkle,
+  classnames: { ...styles },
+  subComponents: {
+    header: modalHeaderSprinkle,
+    body: modalBodySprinkle,
+    footer: modalFooterSprinkle,
+  },
 };
 
 export type { ModalSprinkle } from "./nimbus-modal.types";

--- a/packages/core/styles/src/packages/composite/modal/nimbus-modal.css.ts
+++ b/packages/core/styles/src/packages/composite/modal/nimbus-modal.css.ts
@@ -1,5 +1,9 @@
 import { style, keyframes } from "@vanilla-extract/css";
 import {
+  defineProperties as defineSprinkleProperties,
+  createSprinkles,
+} from "@vanilla-extract/sprinkles";
+import {
   createRainbowSprinkles,
   defineProperties as defineRainbowProperties,
 } from "rainbow-sprinkles";
@@ -20,6 +24,7 @@ export const container = style({
   flexWrap: "nowrap",
   height: "auto",
 
+  gap: varsThemeBase.spacing[4],
   backgroundColor: varsThemeBase.colors.neutral.background,
   borderRadius: varsThemeBase.shape.border.radius[2],
   boxSizing: "border-box",
@@ -51,14 +56,6 @@ const container__close = style({
   ":active": {
     backgroundColor: varsThemeBase.colors.neutral.interactivePressed,
   },
-});
-
-const container__header = style({
-  marginBottom: "1.125rem",
-});
-
-const container__body = style({
-  marginBottom: "1rem",
 });
 
 const container__footer = style({
@@ -96,8 +93,6 @@ export const styles = {
   overlay,
   container,
   container__close,
-  container__header,
-  container__body,
   container__footer,
 };
 
@@ -105,7 +100,7 @@ export const styles = {
  * Sprinkle
  * -----------------------------------------------------------------------------------------------*/
 
-const properties = {
+const modalProperties = {
   padding: paddingProperties,
 };
 
@@ -131,9 +126,58 @@ const defineProperties = defineRainbowProperties({
   },
 });
 
-const sprinkle = createRainbowSprinkles(defineProperties);
-
 export const modalSprinkle = {
-  sprinkle,
-  properties,
+  sprinkle: createRainbowSprinkles(defineProperties),
+  properties: modalProperties,
+};
+
+const modalHeaderProperties = {
+  padding: {
+    base: `${varsThemeBase.spacing[4]} ${varsThemeBase.spacing[4]} 0 ${varsThemeBase.spacing[4]}`,
+    small: `${varsThemeBase.spacing[2]} ${varsThemeBase.spacing[2]} 0 ${varsThemeBase.spacing[2]}`,
+    none: "0",
+  },
+};
+
+export const modalHeaderSprinkle = {
+  sprinkle: createSprinkles(
+    defineSprinkleProperties({
+      properties: modalHeaderProperties,
+    })
+  ),
+  properties: modalHeaderProperties,
+};
+
+const modalBodyProperties = {
+  padding: {
+    base: `0 ${varsThemeBase.spacing[4]}`,
+    small: `0 ${varsThemeBase.spacing[2]}`,
+    none: "0",
+  },
+};
+
+export const modalBodySprinkle = {
+  sprinkle: createSprinkles(
+    defineSprinkleProperties({
+      properties: modalBodyProperties,
+    })
+  ),
+  properties: modalBodyProperties,
+};
+
+const modalFooterProperties = {
+  padding: {
+    base: `0 ${varsThemeBase.spacing[4]} ${varsThemeBase.spacing[4]} ${varsThemeBase.spacing[4]}`,
+    small: `0 ${varsThemeBase.spacing[2]} ${varsThemeBase.spacing[2]} ${varsThemeBase.spacing[2]}`,
+    none: "0",
+  },
+};
+
+export const modalFooterSprinkle = {
+  sprinkle: createSprinkles(
+    defineSprinkleProperties({
+      properties: modalFooterProperties,
+    })
+  ),
+  properties: modalFooterProperties,
 };

--- a/packages/core/styles/src/packages/composite/sidebar/nimbus-sidebar.css.ts
+++ b/packages/core/styles/src/packages/composite/sidebar/nimbus-sidebar.css.ts
@@ -25,6 +25,7 @@ const container = style({
   overflowY: "auto",
   transition: `opacity ${varsThemeBase.motion.speed.base} ease, transform ${varsThemeBase.motion.speed.base} ease`,
   boxSizing: "border-box",
+  gap: varsThemeBase.spacing[4],
 });
 
 const position = styleVariants({
@@ -65,7 +66,6 @@ const isVisible = style({
 });
 
 const container__header = style({
-  marginBottom: "1rem",
   boxSizing: "border-box",
 });
 
@@ -78,7 +78,6 @@ const container__footer = style({
   width: "100%",
   display: "flex",
   gap: varsThemeBase.spacing[2],
-  marginTop: "1rem",
   boxSizing: "border-box",
   justifyContent: "flex-end",
 });

--- a/packages/core/styles/src/properties/css.ts
+++ b/packages/core/styles/src/properties/css.ts
@@ -16,6 +16,7 @@ import {
   PointerEvents,
   TransitionTiming,
   AlignSelf,
+  WordBreak,
 } from "../types";
 import { baseColors } from "./base";
 
@@ -260,3 +261,10 @@ export const zIndexProperties = {
   "800": varsThemeBase.zIndex[800],
   "900": varsThemeBase.zIndex[900],
 };
+
+export const wordBreakProperties: WordBreak[] = [
+  "normal",
+  "break-all",
+  "keep-all",
+  "break-word",
+];

--- a/packages/core/styles/src/types/index.ts
+++ b/packages/core/styles/src/types/index.ts
@@ -68,3 +68,4 @@ export type TransitionTiming =
   | "linear"
   | "step-start"
   | "step-end";
+export type WordBreak = "normal" | "break-all" | "keep-all" | "break-word";

--- a/packages/core/tokens/CHANGELOG.md
+++ b/packages/core/tokens/CHANGELOG.md
@@ -6,7 +6,7 @@ Our design tokens are the foundations of Nimbus Design System.
 
 #### 💡 Others
 
-- Fixed `neutral-disababled` color token for `#F5F5F5`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+- Fixed `neutral-disababled` color token for `#F5F5F5`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
 
 ## 2023-05-18 `8.0.0`
 

--- a/packages/core/tokens/CHANGELOG.md
+++ b/packages/core/tokens/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Our design tokens are the foundations of Nimbus Design System.
 
+## 2023-06-13 `8.0.1`
+
+#### 💡 Others
+
+- Fixed `neutral-disababled` color token for `#F5F5F5`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2023-05-18 `8.0.0`
 
 #### 🛠 Breaking changes

--- a/packages/core/tokens/src/color/ref.json
+++ b/packages/core/tokens/src/color/ref.json
@@ -64,8 +64,7 @@
       "neutral": {
         "100": { "value": "#FFFFFF" },
         "99": { "value": "#FAFAFA" },
-        "97": { "value": "#F5F5F5" },
-        "95": { "value": "#E7E8E9" },
+        "95": { "value": "#F5F5F5" },
         "90": { "value": "#CFD1D2" },
         "80": { "value": "#B7BABC" },
         "70": { "value": "#A0A3A6" },

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -6,10 +6,11 @@ Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s tea
 
 ### 🎉 New features
 
-- Added `Padding` property to the Component `Card.Header`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
-- Added `Padding` property to the Component `Card.Footer`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
-- Added `Padding` property to the Component `Modal.Header`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
-- Added `Padding` property to the Component `Modal.Footer`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Card.Header`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Card.Footer`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Modal.Header`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Modal.Footer`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `wordBreak` property to the Component `Text` API. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
 
 ## 2023-05-23 `5.0.0`
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2023-06-13 `5.1.0`
+
+### 🎉 New features
+
+- Added `Padding` property to the Component `Card.Header`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Card.Footer`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Modal.Header`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Modal.Footer`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2023-05-23 `5.0.0`
 
 #### 🛠 Breaking changes

--- a/packages/react/src/atomic/Box/src/box.stories.tsx
+++ b/packages/react/src/atomic/Box/src/box.stories.tsx
@@ -1,5 +1,7 @@
 import React, { forwardRef } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
+import { box } from "@nimbus-ds/styles";
+import { argTypesConvert } from ".storybook/utils";
 import { Box as BoxComponent, BoxProps } from "./Box";
 
 export const Basic: React.FC<BoxProps> = forwardRef((props: BoxProps) => (
@@ -20,6 +22,7 @@ const meta: Meta<typeof Basic> = {
         "A ref to the element rendered by this component. Because this component is polymorphic, the type will vary based on the value of the as prop.",
     },
     children: { control: { type: "text" } },
+    ...argTypesConvert(box.properties),
   },
   tags: ["autodocs"],
 };

--- a/packages/react/src/atomic/IconButton/src/iconButton.stories.tsx
+++ b/packages/react/src/atomic/IconButton/src/iconButton.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { TiendanubeIcon } from "@nimbus-ds/icons";
-
+import { iconButton } from "@nimbus-ds/styles";
+import { argTypesConvert } from ".storybook/utils";
 import { IconButton } from "./IconButton";
 
 TiendanubeIcon.displayName = "TiendanubeIcon";
@@ -11,6 +12,7 @@ const meta: Meta<typeof IconButton> = {
   component: IconButton,
   argTypes: {
     source: { control: { disable: true } },
+    ...argTypesConvert(iconButton.properties),
   },
   tags: ["autodocs"],
 };

--- a/packages/react/src/atomic/Text/CHANGELOG.md
+++ b/packages/react/src/atomic/Text/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Text is a basic component that allows us to write blocks of text and give it formatting to use within other components, sections and pages of our application or website.
 
+## 2023-06-13 `6.3.0`
+
+#### 🎉 New features
+
+- Added `wordBreak` property to the Component `Text` API. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2023-05-22 `6.2.0`
 
 #### 🎉 New features

--- a/packages/react/src/atomic/Text/src/text.stories.tsx
+++ b/packages/react/src/atomic/Text/src/text.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { text } from "@nimbus-ds/styles";
+import { argTypesConvert } from ".storybook/utils";
 import { Text } from "./Text";
 
 const meta: Meta<typeof Text> = {
@@ -6,6 +8,7 @@ const meta: Meta<typeof Text> = {
   component: Text,
   argTypes: {
     children: { control: { type: "text" } },
+    ...argTypesConvert(text.properties),
   },
   tags: ["autodocs"],
 };

--- a/packages/react/src/atomic/Title/src/title.stories.tsx
+++ b/packages/react/src/atomic/Title/src/title.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { title } from "@nimbus-ds/styles";
+import { argTypesConvert } from ".storybook/utils";
 import { Title } from "./Title";
 
 const meta: Meta<typeof Title> = {
@@ -6,6 +8,7 @@ const meta: Meta<typeof Title> = {
   component: Title,
   argTypes: {
     children: { control: { type: "text" } },
+    ...argTypesConvert(title.properties),
   },
   tags: ["autodocs"],
 };

--- a/packages/react/src/composite/Card/CHANGELOG.md
+++ b/packages/react/src/composite/Card/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The Card component allows us to group contents and related actions, making it easier to identify groups of information.
 
+## 2023-06-13 `3.1.0`
+
+#### 🎉 New features
+
+- Added `Padding` property to the Component `Card.Header`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Card.Footer`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2023-04-13 `3.0.1`
 
 #### 🐛 Bug fixes

--- a/packages/react/src/composite/Card/CHANGELOG.md
+++ b/packages/react/src/composite/Card/CHANGELOG.md
@@ -6,8 +6,8 @@ The Card component allows us to group contents and related actions, making it ea
 
 #### 🎉 New features
 
-- Added `Padding` property to the Component `Card.Header`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
-- Added `Padding` property to the Component `Card.Footer`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Card.Header`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Card.Footer`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
 
 ## 2023-04-13 `3.0.1`
 

--- a/packages/react/src/composite/Card/src/card.stories.tsx
+++ b/packages/react/src/composite/Card/src/card.stories.tsx
@@ -21,9 +21,10 @@ type Story = StoryObj<typeof Card>;
 
 export const basic: Story = {
   args: {
+    padding: "none",
     children: (
       <>
-        <Card.Header>
+        <Card.Header padding="base">
           <Box
             display="flex"
             justifyContent="space-between"
@@ -33,13 +34,13 @@ export const basic: Story = {
             <Tag appearance="primary">Text</Tag>
           </Box>
         </Card.Header>
-        <Card.Body>
+        <Card.Body padding="base">
           <Text textAlign="left">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam sed
             tortor hendrerit, varius nulla tristique.
           </Text>
         </Card.Body>
-        <Card.Footer>
+        <Card.Footer padding="base">
           <Button appearance="neutral">Button</Button>
           <Button appearance="primary">Button</Button>
         </Card.Footer>

--- a/packages/react/src/composite/Card/src/components/CardBody/CardBody.tsx
+++ b/packages/react/src/composite/Card/src/components/CardBody/CardBody.tsx
@@ -10,7 +10,7 @@ const CardBody: React.FC<CardBodyProps> = ({
   children,
   ...rest
 }) => (
-  <div className={card.sprinkle({ padding })} {...rest}>
+  <div className={card.subComponents.body.sprinkle({ padding })} {...rest}>
     {children}
   </div>
 );

--- a/packages/react/src/composite/Card/src/components/CardBody/cardBody.types.ts
+++ b/packages/react/src/composite/Card/src/components/CardBody/cardBody.types.ts
@@ -11,7 +11,7 @@ export interface CardBodyProperties {
    * The padding properties are used to generate space around an card's body content area.
    * @default none
    */
-  padding?: keyof typeof card.properties.padding;
+  padding?: keyof typeof card.subComponents.body.properties.padding;
 }
 
 export type CardBodyProps = CardBodyProperties & HTMLAttributes<HTMLElement>;

--- a/packages/react/src/composite/Card/src/components/CardFooter/CardFooter.tsx
+++ b/packages/react/src/composite/Card/src/components/CardFooter/CardFooter.tsx
@@ -6,10 +6,17 @@ import { CardFooterProps } from "./cardFooter.types";
 const CardFooter: React.FC<CardFooterProps> = ({
   className: _className,
   style: _style,
+  padding = "none",
   children,
   ...rest
 }) => (
-  <div className={card.classnames.container__footer} {...rest}>
+  <div
+    className={[
+      card.classnames.container__footer,
+      card.subComponents.footer.sprinkle({ padding }),
+    ].join(" ")}
+    {...rest}
+  >
     {children}
   </div>
 );

--- a/packages/react/src/composite/Card/src/components/CardFooter/cardFooter.types.ts
+++ b/packages/react/src/composite/Card/src/components/CardFooter/cardFooter.types.ts
@@ -1,3 +1,4 @@
+import { card } from "@nimbus-ds/styles";
 import { HTMLAttributes, ReactNode } from "react";
 
 export interface CardFooterProperties {
@@ -6,6 +7,11 @@ export interface CardFooterProperties {
    * @TJS-type React.ReactNode
    */
   children: ReactNode;
+  /**
+   * The padding properties are used to generate space around an card's footer content area.
+   * @default none
+   */
+  padding?: keyof typeof card.subComponents.footer.properties.padding;
 }
 
 export type CardFooterProps = CardFooterProperties &

--- a/packages/react/src/composite/Card/src/components/CardHeader/CardHeader.tsx
+++ b/packages/react/src/composite/Card/src/components/CardHeader/CardHeader.tsx
@@ -1,16 +1,18 @@
 import React from "react";
 import { Title } from "@nimbus-ds/title";
+import { card } from "@nimbus-ds/styles";
 
 import { CardHeaderProps } from "./cardHeader.types";
 
 const CardHeader: React.FC<CardHeaderProps> = ({
   className: _className,
   style: _style,
+  padding = "none",
   title,
   children,
   ...rest
 }) => (
-  <div {...rest}>
+  <div className={card.subComponents.header.sprinkle({ padding })} {...rest}>
     {title && (
       <Title data-testid="header-title" as="h3">
         {title}

--- a/packages/react/src/composite/Card/src/components/CardHeader/cardHeader.types.ts
+++ b/packages/react/src/composite/Card/src/components/CardHeader/cardHeader.types.ts
@@ -1,4 +1,5 @@
 import { HTMLAttributes, ReactNode } from "react";
+import { card } from "@nimbus-ds/styles";
 
 export interface CardHeaderProperties {
   /**
@@ -10,6 +11,11 @@ export interface CardHeaderProperties {
    * The title to display in the card header.
    */
   title?: string;
+  /**
+   * The padding properties are used to generate space around an card's header content area.
+   * @default none
+   */
+  padding?: keyof typeof card.subComponents.header.properties.padding;
 }
 
 export type CardHeaderProps = CardHeaderProperties &

--- a/packages/react/src/composite/Modal/CHANGELOG.md
+++ b/packages/react/src/composite/Modal/CHANGELOG.md
@@ -6,8 +6,8 @@ The Modal component allows us to call the user's attention to a floating box tha
 
 #### 🎉 New features
 
-- Added `Padding` property to the Component `Modal.Header`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
-- Added `Padding` property to the Component `Modal.Footer`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Modal.Header`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Modal.Footer`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
 
 ## 2023-05-22 `1.3.1`
 

--- a/packages/react/src/composite/Modal/CHANGELOG.md
+++ b/packages/react/src/composite/Modal/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The Modal component allows us to call the user's attention to a floating box that can have text, actions or forms to perform tasks by changing the focus from the background. It is an intrusive component as it interrupts the user's operation to present a message or content.
 
+## 2023-06-13 `1.4.0`
+
+#### 🎉 New features
+
+- Added `Padding` property to the Component `Modal.Header`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+- Added `Padding` property to the Component `Modal.Footer`. ([#168](https://github.com/TiendaNube/nimbus-design-system/pull/168) by [@juniorconquista](https://github.com/juniorconquista))
+
 ## 2023-05-22 `1.3.1`
 
 ### 🐛 Bug fixes

--- a/packages/react/src/composite/Modal/src/components/ModalBody/ModalBody.tsx
+++ b/packages/react/src/composite/Modal/src/components/ModalBody/ModalBody.tsx
@@ -9,22 +9,10 @@ const ModalBody: React.FC<ModalBodyProps> = ({
   padding = "base",
   children,
   ...rest
-}) => {
-  const { className, style, otherProps } = modal.sprinkle({
-    ...(rest as Parameters<typeof modal.sprinkle>[0]),
-    padding: padding as any,
-  });
-
-  return (
-    <div
-      {...otherProps}
-      style={style}
-      className={[modal.classnames.container__body, className].join(" ")}
-      {...rest}
-    >
-      {children}
-    </div>
-  );
-};
+}) => (
+  <div className={modal.subComponents.body.sprinkle({ padding })} {...rest}>
+    {children}
+  </div>
+);
 
 export { ModalBody };

--- a/packages/react/src/composite/Modal/src/components/ModalBody/modalBody.spec.tsx
+++ b/packages/react/src/composite/Modal/src/components/ModalBody/modalBody.spec.tsx
@@ -19,30 +19,31 @@ describe("GIVEN <Modal.Body />", () => {
   describe("THEN should correctly render the submitted padding", () => {
     it("THEN should correctly render the padding default", () => {
       makeSut({ children: "My content" });
-      expect(screen.getByTestId("body-element").getAttribute("style")).toMatch(
-        /--padding-xs__\w{0,9}: var\(--spacing-4__\w{0,9}\);/
-      );
+      expect(
+        screen.getByTestId("body-element").getAttribute("class")
+      ).toContain("padding_base");
     });
 
     it("AND should correctly render the padding none", () => {
       makeSut({ padding: "none", children: "My content" });
-      expect(screen.getByTestId("body-element").getAttribute("style")).toMatch(
-        /--padding-xs__\w{0,9}: 0;/
-      );
+      expect(
+        screen.getByTestId("body-element").getAttribute("class")
+      ).toContain("padding_none");
     });
 
     it("AND should correctly render the padding base", () => {
       makeSut({ padding: "base", children: "My content" });
-      expect(screen.getByTestId("body-element").getAttribute("style")).toMatch(
-        /--padding-xs__\w{0,9}: var\(--spacing-4__\w{0,9}\);/
-      );
+      screen.debug();
+      expect(
+        screen.getByTestId("body-element").getAttribute("class")
+      ).toContain("padding_base");
     });
 
     it("AND should correctly render the padding small", () => {
       makeSut({ padding: "small", children: "My content" });
-      expect(screen.getByTestId("body-element").getAttribute("style")).toMatch(
-        /--padding-xs__\w{0,9}: var\(--spacing-2__\w{0,9}\);/
-      );
+      expect(
+        screen.getByTestId("body-element").getAttribute("class")
+      ).toContain("padding_small");
     });
   });
 });

--- a/packages/react/src/composite/Modal/src/components/ModalBody/modalBody.types.ts
+++ b/packages/react/src/composite/Modal/src/components/ModalBody/modalBody.types.ts
@@ -1,5 +1,5 @@
 import { HTMLAttributes, ReactNode } from "react";
-import { card } from "@nimbus-ds/styles";
+import { modal } from "@nimbus-ds/styles";
 
 export interface ModalBodyProperties {
   /**
@@ -9,9 +9,9 @@ export interface ModalBodyProperties {
   children: ReactNode;
   /**
    * The padding properties are used to generate space around an modal's body content area.
-   * @default base
+   * @default none
    */
-  padding?: keyof typeof card.properties.padding;
+  padding?: keyof typeof modal.subComponents.body.properties.padding;
 }
 
 export type ModalBodyProps = ModalBodyProperties & HTMLAttributes<HTMLElement>;

--- a/packages/react/src/composite/Modal/src/components/ModalFooter/ModalFooter.tsx
+++ b/packages/react/src/composite/Modal/src/components/ModalFooter/ModalFooter.tsx
@@ -6,10 +6,17 @@ import { ModalFooterProps } from "./modalFooter.types";
 const ModalFooter: React.FC<ModalFooterProps> = ({
   className: _className,
   style: _style,
+  padding = "none",
   children,
   ...rest
 }) => (
-  <div className={modal.classnames.container__footer} {...rest}>
+  <div
+    className={[
+      modal.subComponents.body.sprinkle({ padding }),
+      modal.classnames.container__footer,
+    ].join(" ")}
+    {...rest}
+  >
     {children}
   </div>
 );

--- a/packages/react/src/composite/Modal/src/components/ModalFooter/modalFooter.types.ts
+++ b/packages/react/src/composite/Modal/src/components/ModalFooter/modalFooter.types.ts
@@ -1,4 +1,5 @@
 import { HTMLAttributes, ReactNode } from "react";
+import { modal } from "@nimbus-ds/styles";
 
 export interface ModalFooterProperties {
   /**
@@ -6,6 +7,11 @@ export interface ModalFooterProperties {
    * @TJS-type React.ReactNode
    */
   children: ReactNode;
+  /**
+   * The padding properties are used to generate space around an modal's footer content area.
+   * @default none
+   */
+  padding?: keyof typeof modal.subComponents.footer.properties.padding;
 }
 
 export type ModalFooterProps = ModalFooterProperties &

--- a/packages/react/src/composite/Modal/src/components/ModalHeader/ModalHeader.tsx
+++ b/packages/react/src/composite/Modal/src/components/ModalHeader/ModalHeader.tsx
@@ -7,11 +7,12 @@ import { ModalHeaderProps } from "./modalHeader.types";
 const ModalHeader: React.FC<ModalHeaderProps> = ({
   className: _className,
   style: _style,
+  padding = "none",
   title,
   children,
   ...rest
 }) => (
-  <div {...rest} className={modal.classnames.container__header}>
+  <div className={modal.subComponents.header.sprinkle({ padding })} {...rest}>
     {title && (
       <Title data-testid="header-title" as="h3">
         {title}

--- a/packages/react/src/composite/Modal/src/components/ModalHeader/modalHeader.types.ts
+++ b/packages/react/src/composite/Modal/src/components/ModalHeader/modalHeader.types.ts
@@ -1,4 +1,5 @@
 import { HTMLAttributes, ReactNode } from "react";
+import { modal } from "@nimbus-ds/styles";
 
 export interface ModalHeaderProperties {
   /**
@@ -10,6 +11,11 @@ export interface ModalHeaderProperties {
    * The title to display in the modal header.
    */
   title?: string;
+  /**
+   * The padding properties are used to generate space around an modal's header content area.
+   * @default none
+   */
+  padding?: keyof typeof modal.subComponents.header.properties.padding;
 }
 
 export type ModalHeaderProps = ModalHeaderProperties &

--- a/packages/react/src/composite/Sidebar/src/sidebar.stories.tsx
+++ b/packages/react/src/composite/Sidebar/src/sidebar.stories.tsx
@@ -4,6 +4,8 @@ import { useArgs } from "@storybook/client-api";
 import { Box } from "@nimbus-ds/box";
 import { Button } from "@nimbus-ds/button";
 import { Text } from "@nimbus-ds/text";
+import { sidebar } from "@nimbus-ds/styles";
+import { argTypesConvert } from ".storybook/utils";
 import { Sidebar } from "./Sidebar";
 import { SidebarProps } from "./sidebar.types";
 
@@ -12,6 +14,7 @@ const meta: Meta<typeof Sidebar> = {
   component: Sidebar,
   argTypes: {
     children: { control: { disable: true } },
+    ...argTypesConvert(sidebar.properties),
   },
   tags: ["autodocs"],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     "types": ["node", "jest"],
     "typeRoots": ["./node_modules/@types", "./types"],
     "paths": {
+      "@nimbus-ds/storybook": ["./storybook"],
       "@nimbus-ds/icons": ["./packages/icons/tmp"],
       "@nimbus-ds/tokens": ["./packages/core/tokens/dist"],
       "@nimbus-ds/typings": ["./packages/core/typings/src"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6775,6 +6775,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-module-resolver@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "babel-plugin-module-resolver@npm:5.0.0"
+  dependencies:
+    find-babel-config: ^2.0.0
+    glob: ^8.0.3
+    pkg-up: ^3.1.0
+    reselect: ^4.1.7
+    resolve: ^1.22.1
+  checksum: d6880e49fc8e7bac509a2c183b4303ee054a47a80032a59a6f7844bb468ebe5e333b5dc5378443afdab5839e2da2b31a6c8d9a985a0047cd076b82bb9161cc78
+  languageName: node
+  linkType: hard
+
 "babel-plugin-named-exports-order@npm:^0.0.2":
   version: 0.0.2
   resolution: "babel-plugin-named-exports-order@npm:0.0.2"
@@ -10014,6 +10027,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-babel-config@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "find-babel-config@npm:2.0.0"
+  dependencies:
+    json5: ^2.1.1
+    path-exists: ^4.0.0
+  checksum: d110308b02fe6a6411a0cfb7fd50af6740fbf5093eada3d6ddacf99b07fc8eea4aa3475356484710a0032433029a21ce733bb3ef88fda1d6e35c29a3e4983014
+  languageName: node
+  linkType: hard
+
 "find-cache-dir@npm:^2.0.0":
   version: 2.1.0
   resolution: "find-cache-dir@npm:2.1.0"
@@ -12437,7 +12460,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.1.2, json5@npm:^2.2.1, json5@npm:^2.2.2":
+"json5@npm:^2.1.1, json5@npm:^2.1.2, json5@npm:^2.2.1, json5@npm:^2.2.2":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -14084,6 +14107,7 @@ __metadata:
     "@vanilla-extract/webpack-plugin": ^2.2.0
     babel-jest: ^28.1.3
     babel-loader: ^8.2.5
+    babel-plugin-module-resolver: ^5.0.0
     child_process: ^1.0.2
     dts-bundle-generator: ^7.1.0
     eslint: ^8.19.0
@@ -16076,6 +16100,13 @@ __metadata:
   version: 1.0.0
   resolution: "requires-port@npm:1.0.0"
   checksum: eee0e303adffb69be55d1a214e415cf42b7441ae858c76dfc5353148644f6fd6e698926fc4643f510d5c126d12a705e7c8ed7e38061113bdf37547ab356797ff
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^4.1.7":
+  version: 4.1.8
+  resolution: "reselect@npm:4.1.8"
+  checksum: a4ac87cedab198769a29be92bc221c32da76cfdad6911eda67b4d3e7136dca86208c3b210e31632eae31ebd2cded18596f0dd230d3ccc9e978df22f233b5583e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛
- [x] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

### `@nimbus-ds/tokens@8.0.1|patch`

#### 💡 Others

- Fixed `neutral-disababled` color token for `#F5F5F5`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))

### `@nimbus-ds/styles@9.1.0|minor`

#### 🎉 New features

- Added new wordbreak prop in Text component style pack. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))

#### 💡 Others

- Spacing adjustments in Card, Modal and Sidebar component style packs. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))

### `@nimbus-ds/componentes@5.1.0|minor`

#### 🎉 New features

- Added `Padding` property to the Component `Card.Header`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
- Added `Padding` property to the Component `Card.Footer`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
- Added `Padding` property to the Component `Modal.Header`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
- Added `Padding` property to the Component `Modal.Footer`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
- Added `wordBreak` property to the Component `Text` API. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))

### `@nimbus-ds/card@3.1.0|minor`

#### 🎉 New features

- Added `Padding` property to the Component `Card.Header`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
- Added `Padding` property to the Component `Card.Footer`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))

### `@nimbus-ds/modal@1.4.0|minor`

#### 🎉 New features

- Added `Padding` property to the Component `Modal.Header`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))
- Added `Padding` property to the Component `Modal.Footer`. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))

### `@nimbus-ds/text@6.3.0|minor`

#### 🎉 New features

- Added `wordBreak` property to the Component `Text` API. ([#169](https://github.com/TiendaNube/nimbus-design-system/pull/169) by [@juniorconquista](https://github.com/juniorconquista))

