### PR TITLE
Feat: Tabs.Item new prop `labelContent` [ECNIM-901]

### DIFF
--- a/.yarn/versions/7e1136ec.yml
+++ b/.yarn/versions/7e1136ec.yml
@@ -1,0 +1,7 @@
+releases:
+  "@nimbus-ds/components": minor
+  "@nimbus-ds/styles": minor
+  "@nimbus-ds/tabs": minor
+
+declined:
+  - nimbus-design-system

--- a/packages/core/styles/CHANGELOG.md
+++ b/packages/core/styles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Nimbus Styles deprive all styles needed to build nimbus components.
 
+## 2024-01-18 `9.10.0`
+
+- Update style package of `Tabs` component. ([#216](https://github.com/TiendaNube/nimbus-design-system/pull/216) by [@juanchigallego](https://github.com/juanchigallego))
+
 ## 2023-12-22 `9.9.0`
 
 #### 🎉 New features

--- a/packages/core/styles/package.json
+++ b/packages/core/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/styles",
-  "version": "9.9.0-rc.3",
+  "version": "9.9.0",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
@@ -32,6 +32,5 @@
     "glob": "^8.0.3",
     "rainbow-sprinkles": "^0.14.0",
     "ts-node": "^10.9.1"
-  },
-  "stableVersion": "9.8.0"
+  }
 }

--- a/packages/core/styles/src/packages/composite/tabs/nimbus-tabs.css.ts
+++ b/packages/core/styles/src/packages/composite/tabs/nimbus-tabs.css.ts
@@ -21,13 +21,16 @@ export const container__item = styleVariants({
 });
 
 const button = vanillaStyle({
+  alignItems: "center",
   appearance: "none",
   background: "transparent",
   cursor: "pointer",
   position: "relative",
   border: 0,
-  display: "block",
+  display: "flex",
+  gap: varsThemeBase.spacing[1],
   margin: "0 auto",
+  maxHeight: "32px",
   borderRadius: varsThemeBase.shape.border.radius[1],
   paddingBottom: varsThemeBase.spacing[2],
   paddingLeft: varsThemeBase.spacing[6],

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2024-01-18 `5.4.0`
+
+### 🎉 New features
+
+- Add `labelContent` prop to `Tabs.Item` subcomponent to include a child node on the tab button. ([#216](https://github.com/TiendaNube/nimbus-design-system/pull/216) by [@juanchigallego](https://github.com/juanchigallego))
+
 ## 2023-12-22 `5.3.2`
 
 #### 🎉 New features

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/components",
-  "version": "5.3.2-rc.3",
+  "version": "5.3.2",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
@@ -31,6 +31,5 @@
   },
   "devDependencies": {
     "@nimbus-ds/webpack": "workspace:^"
-  },
-  "stableVersion": "5.3.1"
+  }
 }

--- a/packages/react/src/composite/Tabs/CHANGELOG.md
+++ b/packages/react/src/composite/Tabs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The Tabs component allows us to separate content from the same hierarchy into different tabs.
 
+## 2024-01-18 `2.3.0`
+
+### 🎉 New features
+
+- Add `labelContent` prop to `Tabs.Item` subcomponent to include a child node on the tab button. ([#216](https://github.com/TiendaNube/nimbus-design-system/pull/216) by [@juanchigallego](https://github.com/juanchigallego))
+
 ## 2023-03-13 `2.2.0`
 
 ### 💡 Others

--- a/packages/react/src/composite/Tabs/src/Tabs.tsx
+++ b/packages/react/src/composite/Tabs/src/Tabs.tsx
@@ -18,7 +18,7 @@ const Tabs: React.FC<TabsProps> & TabsComponents = ({
       <ul role="tablist" className={tabs.classnames.container}>
         {React.Children.map(children, (item, index) => {
           const {
-            props: { label },
+            props: { label, labelContent },
           } = item;
           return (
             <Tabs.Button
@@ -28,6 +28,7 @@ const Tabs: React.FC<TabsProps> & TabsComponents = ({
               active={index === selectedTab}
               setActiveTab={setSelectedTab}
               fullWidth={fullWidth}
+              labelContent={labelContent}
             />
           );
         })}

--- a/packages/react/src/composite/Tabs/src/components/TabsButton/TabsButton.tsx
+++ b/packages/react/src/composite/Tabs/src/components/TabsButton/TabsButton.tsx
@@ -8,6 +8,7 @@ const TabsButton: React.FC<TabsButtonProps> = ({
   className: _className,
   style: _style,
   label,
+  labelContent,
   active = false,
   index,
   setActiveTab,
@@ -41,6 +42,7 @@ const TabsButton: React.FC<TabsButtonProps> = ({
         tabIndex={0}
       >
         {label}
+        {labelContent}
       </button>
     </li>
   );

--- a/packages/react/src/composite/Tabs/src/components/TabsButton/tabsButton.spec.tsx
+++ b/packages/react/src/composite/Tabs/src/components/TabsButton/tabsButton.spec.tsx
@@ -5,6 +5,7 @@ import { TabsButton } from "./TabsButton";
 import { TabsButtonProps } from "./tabsButton.types";
 
 const buttonLabel = "myButtonLabel";
+const buttonLabelReactNode = <p data-testid="label-element">myButtonContent</p>;
 const mockedSetActiveTab = jest.fn();
 
 const makeSut = (
@@ -47,5 +48,12 @@ describe("GIVEN <Button />", () => {
     const tabButton = screen.getByRole("tab");
     fireEvent.click(tabButton);
     expect(mockedSetActiveTab).toBeCalled();
+  });
+
+  it("THEN should correctly render the label child node properly", () => {
+    makeSut({ labelContent: buttonLabelReactNode });
+    expect(screen.getByTestId("label-element").textContent).toContain(
+      "myButtonContent"
+    );
   });
 });

--- a/packages/react/src/composite/Tabs/src/components/TabsButton/tabsButton.types.ts
+++ b/packages/react/src/composite/Tabs/src/components/TabsButton/tabsButton.types.ts
@@ -1,10 +1,14 @@
-import { HTMLAttributes } from "react";
+import { HTMLAttributes, ReactNode } from "react";
 
 export interface TabsButtonProperties {
   /**
    * Label of the tab button.
    */
   label: string;
+  /**
+   * Content of the tab button.
+   */
+  labelContent?: ReactNode;
   /**
    * Determines if tab is active.
    * @default false

--- a/packages/react/src/composite/Tabs/src/components/TabsItem/tabsItem.types.ts
+++ b/packages/react/src/composite/Tabs/src/components/TabsItem/tabsItem.types.ts
@@ -6,6 +6,11 @@ export interface TabsItemProperties {
    */
   label: string;
   /**
+   * Optional content of the tabpanel.
+   * @TJS-type ReactNode;
+   */
+  labelContent?: ReactNode;
+  /**
    * The content of the tabs item.
    * @TJS-type ReactNode | ReactNode[];
    */

--- a/packages/react/src/composite/Tabs/src/tabs.stories.tsx
+++ b/packages/react/src/composite/Tabs/src/tabs.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Box } from "@nimbus-ds/box";
 import { Text } from "@nimbus-ds/text";
+import { Tag } from "@nimbus-ds/tag";
 import { Tabs } from "./Tabs";
 
 const meta: Meta<typeof Tabs> = {
@@ -9,7 +10,7 @@ const meta: Meta<typeof Tabs> = {
   component: Tabs,
   render: (args) => (
     <Tabs {...args}>
-      <Tabs.Item label="Tab 1">
+      <Tabs.Item label="Tab 1" labelContent={<Tag>Some tag</Tag>}>
         <Box
           borderColor="neutral-interactive"
           borderStyle="dashed"


### PR DESCRIPTION
## Type

- [ ] Bugfix 🐛
- [x] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

## `@nimbus-ds/components@5.4.0`

### 🎉 New features

- Add `labelContent` prop to `Tabs.Item` subcomponent to include a child node on the tab button. ([#216](https://github.com/TiendaNube/nimbus-design-system/pull/216) by [@juanchigallego](https://github.com/juanchigallego))

## `@nimbus-ds/tabs@2.3.0`

### 🎉 New features

- Add `labelContent` prop to `Tabs.Item` subcomponent to include a child node on the tab button. ([#216](https://github.com/TiendaNube/nimbus-design-system/pull/216) by [@juanchigallego](https://github.com/juanchigallego))

## `@nimbus-ds/styles@9.10.0`

- Update style package of `Tabs` component. ([#216](https://github.com/TiendaNube/nimbus-design-system/pull/216) by [@juanchigallego](https://github.com/juanchigallego))