### PR TITLE
Feat: Add trim to chip component [ECNIM-907]

### DIFF
--- a/.yarn/versions/d2637ecc.yml
+++ b/.yarn/versions/d2637ecc.yml
@@ -1,0 +1,6 @@
+releases:
+  "@nimbus-ds/chip": patch
+  "@nimbus-ds/components": patch
+
+declined:
+  - nimbus-design-system

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2024-02-07 `5.4.1`
+
+### 🐛 Bug fixes
+
+- Added `lineClamp` and `wordBreak` properties to `Chip` Text to allow overflowing text to hide instead of breaking into lines. ([#220](https://github.com/TiendaNube/nimbus-design-system/pull/220) by [@juanchigallego](https://github.com/juanchigallego))
+
 ## 2024-01-18 `5.4.0`
 
 ### 🎉 New features

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/components",
-  "version": "5.3.2",
+  "version": "5.4.0",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [

--- a/packages/react/src/atomic/Chip/CHANGELOG.md
+++ b/packages/react/src/atomic/Chip/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The Chip component is used to flag criteria or attributes related to searches or filters of a list of information.
 
+## 2024-02-07 `2.3.2`
+
+### 🐛 Bug fixes
+
+- Added `lineClamp` and `wordBreak` properties to `Chip` Text to allow overflowing text to hide instead of breaking into lines. ([#220](https://github.com/TiendaNube/nimbus-design-system/pull/220) by [@juanchigallego](https://github.com/juanchigallego))
+
 ## 2023-12-22 `2.3.1`
 
 - Update component with new color tokens from `@nimbus-ds/tokens` package. ([#215](https://github.com/TiendaNube/nimbus-design-system/pull/215) by [@juanchigallego](https://github.com/juanchigallego))

--- a/packages/react/src/atomic/Chip/package.json
+++ b/packages/react/src/atomic/Chip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/chip",
-  "version": "2.3.1-rc.3",
+  "version": "2.3.1",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
@@ -32,8 +32,7 @@
     "url": "https://github.com/TiendaNube/nimbus-design-system/issues"
   },
   "devDependencies": {
-    "@nimbus-ds/webpack": "workspace:^",
-    "@nimbus-ds/box": "workspace:^"
-  },
-  "stableVersion": "2.3.0"
+    "@nimbus-ds/box": "workspace:^",
+    "@nimbus-ds/webpack": "workspace:^"
+  }
 }

--- a/packages/react/src/atomic/Chip/package.json
+++ b/packages/react/src/atomic/Chip/package.json
@@ -32,7 +32,8 @@
     "url": "https://github.com/TiendaNube/nimbus-design-system/issues"
   },
   "devDependencies": {
-    "@nimbus-ds/webpack": "workspace:^"
+    "@nimbus-ds/webpack": "workspace:^",
+    "@nimbus-ds/box": "workspace:^"
   },
   "stableVersion": "2.3.0"
 }

--- a/packages/react/src/atomic/Chip/src/Chip.tsx
+++ b/packages/react/src/atomic/Chip/src/Chip.tsx
@@ -17,7 +17,13 @@ const Chip: React.FC<ChipProps> & ChipComponents = ({
 }: ChipProps) => (
   <button type="button" {...rest} className={chip.classnames.base}>
     {icon && <Icon source={icon} color="neutral-textHigh" />}
-    <Text color="neutral-textHigh" fontSize="caption" lineHeight="caption">
+    <Text
+      color="neutral-textHigh"
+      fontSize="caption"
+      lineHeight="caption"
+      lineClamp={1}
+      wordBreak="break-all"
+    >
       {text}
     </Text>
     {removable && (

--- a/packages/react/src/atomic/Chip/src/chip.stories.tsx
+++ b/packages/react/src/atomic/Chip/src/chip.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { BoxPackedIcon } from "@nimbus-ds/icons";
+import { Box } from "@nimbus-ds/box";
 import { Chip } from "./Chip";
 
 const meta: Meta<typeof Chip> = {
@@ -25,6 +26,24 @@ export const basic: Story = {
 export const removable: Story = {
   args: {
     text: "Text",
+    icon: <BoxPackedIcon size={12} />,
+    removable: true,
+  },
+};
+
+export const stressed: Story = {
+  render: (args) => {
+    const chips = Array.from({ length: 5 }, (_, index) => (
+      <Chip key={index} {...args} />
+    ));
+    return (
+      <Box display="flex" flexWrap="wrap" gap="2">
+        {chips}
+      </Box>
+    );
+  },
+  args: {
+    text: "This is a very stressed chip to showcase what happens when there's a lot of text",
     icon: <BoxPackedIcon size={12} />,
     removable: true,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4473,6 +4473,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/chip@workspace:packages/react/src/atomic/Chip"
   dependencies:
+    "@nimbus-ds/box": "workspace:^"
     "@nimbus-ds/icon": "workspace:^"
     "@nimbus-ds/icons": "workspace:^"
     "@nimbus-ds/skeleton": "workspace:^"


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛
- [ ] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

## `@nimbus-ds/components@5.4.1`

### 🐛 Bug fixes

- Added `lineClamp` and `wordBreak` properties to `Chip` Text to allow overflowing text to hide instead of breaking into lines. ([#220](https://github.com/TiendaNube/nimbus-design-system/pull/220) by [@juanchigallego](https://github.com/juanchigallego))

## `@nimbus-ds/chip@2.3.2`

### 🐛 Bug fixes

- Added `lineClamp` and `wordBreak` properties to `Chip` Text to allow overflowing text to hide instead of breaking into lines. ([#220](https://github.com/TiendaNube/nimbus-design-system/pull/220) by [@juanchigallego](https://github.com/juanchigallego))