### PR TITLE
feat: add neutral-background to title color style props

### DIFF
--- a/.yarn/versions/a46f1ae8.yml
+++ b/.yarn/versions/a46f1ae8.yml
@@ -1,0 +1,5 @@
+releases:
+  "@nimbus-ds/styles": minor
+
+declined:
+  - nimbus-design-system

--- a/packages/core/styles/CHANGELOG.md
+++ b/packages/core/styles/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus Styles deprive all styles needed to build nimbus components.
 
+## 2024-02-29 `9.11.0`
+
+#### 🎉 New features
+
+- Add `neutral-background` as option for `Title` style properties. ([#223](https://github.com/TiendaNube/nimbus-design-system/pull/223) by [@juanchigallego](https://github.com/juanchigallego))
+
 ## 2024-01-18 `9.10.0`
 
 - Update style package of `Tabs` component. ([#216](https://github.com/TiendaNube/nimbus-design-system/pull/216) by [@juanchigallego](https://github.com/juanchigallego))

--- a/packages/core/styles/src/packages/atomic/title/nimbus-title.css.ts
+++ b/packages/core/styles/src/packages/atomic/title/nimbus-title.css.ts
@@ -91,6 +91,7 @@ const titleColorProperties = {
   "danger-textLow": colorProperties["danger-textLow"],
   "neutral-textHigh": colorProperties["neutral-textHigh"],
   "neutral-textLow": colorProperties["neutral-textLow"],
+  "neutral-background": colorProperties["neutral-background"],
 };
 
 const fontSizeProperties = {


### PR DESCRIPTION
## Feat: Add neutral-background to title color style props [ECNIM-916]

- [ ] Bugfix 🐛
- [x] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

## `@nimbus-ds/styles@9.11.0`

#### 🎉 New features

- Add `neutral-background` as option for `Title` style properties. ([#223](https://github.com/TiendaNube/nimbus-design-system/pull/223) by [@juanchigallego](https://github.com/juanchigallego))

[ECNIM-916]: https://tiendanube.atlassian.net/browse/ECNIM-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ