### PR TITLE
fix(tabs): align center buttons

### DIFF
--- a/.yarn/versions/4ea2028c.yml
+++ b/.yarn/versions/4ea2028c.yml
@@ -1,0 +1,6 @@
+releases:
+  "@nimbus-ds/styles": patch
+  "@nimbus-ds/tabs": patch
+
+declined:
+  - nimbus-design-system

--- a/.yarn/versions/4ea2028c.yml
+++ b/.yarn/versions/4ea2028c.yml
@@ -1,4 +1,5 @@
 releases:
+  "@nimbus-ds/components": patch
   "@nimbus-ds/styles": patch
   "@nimbus-ds/tabs": patch
 

--- a/packages/core/styles/CHANGELOG.md
+++ b/packages/core/styles/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus Styles deprive all styles needed to build nimbus components.
 
+## 2024-12-18 `9.11.6`
+
+#### 🐛 Bug fixes
+
+- We detected that the content of the Tabs, when set to full, was not centered but aligned to the left. ([#261](https://github.com/TiendaNube/nimbus-design-system/pull/261) by [@harrytiendanube](https://github.com/harrytiendanube) )
+
 ## 2024-04-22 `9.11.5`
 
 #### 💡 Others

--- a/packages/core/styles/src/packages/composite/tabs/nimbus-tabs.css.ts
+++ b/packages/core/styles/src/packages/composite/tabs/nimbus-tabs.css.ts
@@ -72,6 +72,9 @@ export const container__button = styleVariants({
       },
     },
   ],
+  fullWidth: {
+    justifyContent: "center",
+  },
 });
 
 export const container__panel = vanillaStyle({

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2024-12-18 `5.5.5`
+
+#### 🐛 Bug fixes
+
+- We detected that the content of the Tabs, when set to full, was not centered but aligned to the left. ([#261](https://github.com/TiendaNube/nimbus-design-system/pull/261) by [@harrytiendanube](https://github.com/harrytiendanube) )
+
 ## 2024-04-22 `5.5.4`
 
 ### 💡 Others

--- a/packages/react/src/composite/Tabs/CHANGELOG.md
+++ b/packages/react/src/composite/Tabs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The Tabs component allows us to separate content from the same hierarchy into different tabs.
 
+## 2024-12-18 `2.3.0`
+
+#### 🐛 Bug fixes
+
+- We detected that the content of the Tabs, when set to full, was not centered but aligned to the left. ([#261](https://github.com/TiendaNube/nimbus-design-system/pull/261) by [@harrytiendanube](https://github.com/harrytiendanube) )
+
 ## 2024-01-18 `2.3.0`
 
 ### 🎉 New features

--- a/packages/react/src/composite/Tabs/src/components/TabsButton/TabsButton.tsx
+++ b/packages/react/src/composite/Tabs/src/components/TabsButton/TabsButton.tsx
@@ -30,9 +30,10 @@ const TabsButton: React.FC<TabsButtonProps> = ({
       {...rest}
     >
       <button
-        className={
-          tabs.classnames.container__button[active ? "active" : "default"]
-        }
+        className={[
+          tabs.classnames.container__button[active ? "active" : "default"],
+          fullWidth ? tabs.classnames.container__button.fullWidth : "",
+        ].join(" ")}
         onClick={handleOnClick}
         type="button"
         id={`tab-${ariaID}`}


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛

## Changes proposed ✔️

## `@nimbus-ds/components@5.5.5`

### 🐛 Bug fixes

- We detected that the content of the Tabs, when set to full, was not centered but aligned to the left. (https://github.com/TiendaNube/nimbus-design-system/pull/261) by @harrytiendanube )

## `@nimbus-ds/tabs@2.3.1`

### 🐛 Bug fixes

- We detected that the content of the Tabs, when set to full, was not centered but aligned to the left. (https://github.com/TiendaNube/nimbus-design-system/pull/261) by @harrytiendanube )

## `@nimbus-ds/style@9.11.6`

### 🐛 Bug fixes

- We detected that the content of the Tabs, when set to full, was not centered but aligned to the left. (https://github.com/TiendaNube/nimbus-design-system/pull/261) by @harrytiendanube )

