### PR TITLE
fix(radio): background color when disabled and checked

### DIFF
--- a/.yarn/versions/da9e321b.yml
+++ b/.yarn/versions/da9e321b.yml
@@ -1,2 +1,5 @@
 releases:
   "@nimbus-ds/styles": patch
+
+declined:
+  - nimbus-design-system

--- a/.yarn/versions/da9e321b.yml
+++ b/.yarn/versions/da9e321b.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nimbus-ds/styles": patch

--- a/packages/core/styles/src/packages/atomic/radio/nimbus-radio.css.ts
+++ b/packages/core/styles/src/packages/atomic/radio/nimbus-radio.css.ts
@@ -145,9 +145,9 @@ globalStyle(`${container__input}:checked ~ ${container__content.button}`, {
 });
 
 globalStyle(`${container__input}:checked ~ ${container__content.disabled}`, {
-  backgroundColor: varsThemeBase.colors.neutral.surfaceDisabled,
+  backgroundColor: varsThemeBase.colors.neutral.textDisabled,
   borderColor: varsThemeBase.colors.neutral.surfaceHighlight,
-  color: varsThemeBase.colors.neutral.textDisabled,
+  color: varsThemeBase.colors.neutral.background,
 });
 
 export const styles = {


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛

## Changes proposed ✔️

### `@nimbus-ds/style@9.11.7|patch`

#### 🐛 Bug fixes

- We detected that when the radio component, when displayed as a button, didn't match the [Figma](https://www.figma.com/design/TDwgeblsVNeHKKRvoDRk7n/%E2%98%81%EF%B8%8F-Nimbus-v2.0?node-id=2609-46017&p=f&t=4qBwkk1Tk4JoHDsS-0) specified colors for both **disabled** and **checked** enabled attributes at the same time. ([#244](https://github.com/TiendaNube/nimbus-design-system/pull/244) by @diegopsilverio)
