### PR TITLE
Pagination extension

### DIFF
--- a/.yarn/versions/4a3bdfd5.yml
+++ b/.yarn/versions/4a3bdfd5.yml
@@ -1,5 +1,6 @@
 releases:
   "@nimbus-ds/pagination": minor
+  "@nimbus-ds/components": minor
 
 declined:
   - nimbus-design-system

--- a/.yarn/versions/4a3bdfd5.yml
+++ b/.yarn/versions/4a3bdfd5.yml
@@ -1,2 +1,5 @@
 releases:
   "@nimbus-ds/pagination": minor
+
+declined:
+  - nimbus-design-system

--- a/.yarn/versions/4a3bdfd5.yml
+++ b/.yarn/versions/4a3bdfd5.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nimbus-ds/pagination": minor

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -6,7 +6,7 @@ Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s tea
 
 ### 🎉 New features
 
-- The `renderItem` property is added to the pagination component, to be able to have the link functionality in the buttons. ([#269](https://github.com/TiendaNube/nimbus-design-system/pull/269) by [@hrchioest](https://github.com/hrchioest))
+- The `renderItem` property is added to the `Pagination` component, to be able to have the link functionality in the buttons. ([#269](https://github.com/TiendaNube/nimbus-design-system/pull/269) by [@hrchioest](https://github.com/hrchioest))
 
 ## 2025-02-27 `5.5.6`
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2025-03-03 `2.3.0`
+
+### 🎉 New features
+
+- The `renderItem` property is added to the pagination component, to be able to have the link functionality in the buttons. ([#269](https://github.com/TiendaNube/nimbus-design-system/pull/269) by [@hrchioest](https://github.com/hrchioest))
+
 ## 2024-12-18 `5.5.5`
 
 #### 🐛 Bug fixes

--- a/packages/react/src/composite/Pagination/CHANGELOG.md
+++ b/packages/react/src/composite/Pagination/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The Pagination component allows us to navigate between a very large list of entries.
 
+## 2025-03-03 `2.3.0`
+
+### 🎉 New features
+
+- The `renderItem` property is added to the component, to be able to have the link functionality in the buttons. ([#269](https://github.com/TiendaNube/nimbus-design-system/pull/269) by [@hrchioest](https://github.com/hrchioest))
+
 ## 2023-02-23 `2.2.0`
 
 ### 🎉 New features

--- a/packages/react/src/composite/Pagination/src/Pagination.tsx
+++ b/packages/react/src/composite/Pagination/src/Pagination.tsx
@@ -4,7 +4,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from "@nimbus-ds/icons";
 import { Button } from "@nimbus-ds/button";
 
 import { usePagination, DOTS } from "./hooks";
-import { PaginationProps } from "./pagination.types";
+import { PaginationProps, PaginationItemData } from "./pagination.types";
 import { generateKey } from "./pagination.definitions";
 
 const Pagination: React.FC<PaginationProps> = ({
@@ -14,12 +14,29 @@ const Pagination: React.FC<PaginationProps> = ({
   activePage,
   pageCount,
   onPageChange,
+  renderItem,
   ...rest
 }) => {
   const paginationRange = usePagination({
     activePage,
     pageCount,
   });
+
+  const handleRenderItem = (item: PaginationItemData) => {
+    if (renderItem) {
+      return renderItem(item);
+    }
+
+    return (
+      <Button
+        data-testid={`button-pagination-page-${item.pageNumber}`}
+        appearance={item.isCurrent ? "primary" : "transparent"}
+        onClick={() => onPageChange(Number(item.pageNumber))}
+      >
+        {item.pageNumber}
+      </Button>
+    );
+  };
 
   return (
     <ul {...rest} className={pagination.classnames.container}>
@@ -45,17 +62,11 @@ const Pagination: React.FC<PaginationProps> = ({
                 {pageNumber}
               </Button>
             )}
-            {pageNumber !== DOTS && (
-              <Button
-                data-testid={`button-pagination-page-${pageNumber}`}
-                onClick={() => onPageChange(Number(pageNumber))}
-                appearance={
-                  pageNumber === activePage ? "primary" : "transparent"
-                }
-              >
-                {pageNumber}
-              </Button>
-            )}
+            {pageNumber !== DOTS &&
+              handleRenderItem({
+                isCurrent: pageNumber === activePage,
+                pageNumber,
+              })}
           </li>
         ))}
       <li>

--- a/packages/react/src/composite/Pagination/src/Pagination.tsx
+++ b/packages/react/src/composite/Pagination/src/Pagination.tsx
@@ -22,6 +22,7 @@ const Pagination: React.FC<PaginationProps> = ({
     pageCount,
   });
 
+  // Note: If this 'renderItem' function is declared, it renders the item, and if not, by default it renders the Button with the page number.
   const handleRenderItem = (item: PaginationItemData) => {
     if (renderItem) {
       return renderItem(item);

--- a/packages/react/src/composite/Pagination/src/pagination.spec.tsx
+++ b/packages/react/src/composite/Pagination/src/pagination.spec.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { Button } from "@nimbus-ds/button/src";
 
 import { Pagination } from "./Pagination";
 import { PaginationProps } from "./pagination.types";
@@ -120,6 +121,44 @@ describe("GIVEN <Pagination />", () => {
       expect(
         screen.getByTestId<HTMLButtonElement>("button-pagination-next").disabled
       ).toBeTruthy();
+    });
+  });
+  describe("WHEN using renderItem", () => {
+    it("THEN should use the renderItem function to render custom buttons", () => {
+      const mockRenderItem = jest.fn(({ isCurrent, pageNumber }) => (
+        <Button
+          as="a"
+          href={`#${pageNumber}`}
+          data-testid={`button-pagination-page-${pageNumber}`}
+          appearance={isCurrent ? "primary" : "transparent"}
+        >
+          {pageNumber}
+        </Button>
+      ));
+
+      makeSut({
+        activePage: 2,
+        pageCount: 5,
+        renderItem: mockRenderItem,
+      });
+
+      expect(mockRenderItem).toBeDefined();
+      expect(mockRenderItem).toBeCalledWith(
+        expect.objectContaining({
+          isCurrent: expect.any(Boolean),
+          pageNumber: expect.any(Number),
+        })
+      );
+
+      const button = screen.getByTestId("button-pagination-page-2");
+      expect(button).toBeDefined();
+      expect(button).toBeTruthy();
+
+      expect(button.getAttribute("href")).toEqual("#2");
+
+      expect(button.innerHTML).toEqual("2");
+
+      expect(button.className).toContain("primary");
     });
   });
 });

--- a/packages/react/src/composite/Pagination/src/pagination.stories.tsx
+++ b/packages/react/src/composite/Pagination/src/pagination.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useArgs } from "@storybook/preview-api";
+import { Button } from "@nimbus-ds/button";
 import { Pagination } from "./Pagination";
 
 const meta: Meta<typeof Pagination> = {
@@ -56,5 +57,22 @@ export const dotsRight: Story = {
   args: {
     pageCount: 48,
     activePage: 2,
+  },
+};
+
+export const asLink: Story = {
+  args: {
+    pageCount: 48,
+    activePage: 2,
+    renderItem: ({ isCurrent, pageNumber }) => (
+      <Button
+        as="a"
+        href={`#${pageNumber}`}
+        data-testid={`button-pagination-page-${pageNumber}`}
+        appearance={isCurrent ? "primary" : "transparent"}
+      >
+        {pageNumber}
+      </Button>
+    ),
   },
 };

--- a/packages/react/src/composite/Pagination/src/pagination.types.ts
+++ b/packages/react/src/composite/Pagination/src/pagination.types.ts
@@ -1,4 +1,9 @@
-import { HTMLAttributes } from "react";
+import React, { HTMLAttributes } from "react";
+
+export interface PaginationItemData {
+  pageNumber: number | string;
+  isCurrent: boolean;
+}
 
 export interface PaginationProperties {
   /**
@@ -19,6 +24,11 @@ export interface PaginationProperties {
    * @default true
    */
   showNumbers?: boolean;
+
+  /**
+   * Custom render function for pagination items.
+   */
+  renderItem?: (item: PaginationItemData) => React.ReactNode;
 }
 
 export type PaginationProps = PaginationProperties &


### PR DESCRIPTION
## Type

- [ ] Bugfix 🐛
- [X] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

The pagination properties are extended with renderItem so that you can have the buttons as links.

### Todo

An improvement is pending but in the first instance it could help us to have the functionality of having links on the buttons

