### PR TITLE
feat(tabs): adds support for controlled mode

### DIFF
--- a/.yarn/versions/3b1c57fe.yml
+++ b/.yarn/versions/3b1c57fe.yml
@@ -1,0 +1,6 @@
+releases:
+  "@nimbus-ds/components": minor
+  "@nimbus-ds/tabs": minor
+
+declined:
+  - nimbus-design-system

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2025-04-03 `5.10.0`
+
+#### 🐛 New features
+
+- `Tabs`: Adds Controlled component support, with the new `selected` and `onTabSelect` props. ([#282](https://github.com/TiendaNube/nimbus-design-system/pull/282) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-03-25 `5.9.0`
 
 #### 🐛 New features

--- a/packages/react/src/composite/Tabs/CHANGELOG.md
+++ b/packages/react/src/composite/Tabs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The Tabs component allows us to separate content from the same hierarchy into different tabs.
 
+## 2025-04-03 `2.5.0`
+
+#### 🐛 New features
+
+- Adds Controlled component support, with the new `selected` and `onTabSelect` props. ([#282](https://github.com/TiendaNube/nimbus-design-system/pull/282) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-03-18 `2.4.0`
 
 #### 🎉 New features

--- a/packages/react/src/composite/Tabs/src/Tabs.tsx
+++ b/packages/react/src/composite/Tabs/src/Tabs.tsx
@@ -1,29 +1,28 @@
 import React, { useState } from "react";
 import { tabs } from "@nimbus-ds/styles";
 
-import { TabsProps, TabsComponents, ControlledTabsProperties, BaseTabsProperties } from "./tabs.types";
+import { TabsProps, TabsComponents } from "./tabs.types";
 import { TabsButton, TabsItem } from "./components";
+import { isControlled } from "./tabs.definitions";
 
-const isControlled = (props: BaseTabsProperties | ControlledTabsProperties): props is ControlledTabsProperties => {
-  return 'selected' in props && 'onSelect' in props;
-};
-
-const Tabs: React.FC<TabsProps> & TabsComponents = (props) => {
-  const {
-    className: _className,
-    style: _style,
-    children,
-    preSelectedTab,
-    fullWidth = false,
-    ...rest
-  } = props;
-
+const Tabs: React.FC<TabsProps> & TabsComponents = ({
+  className: _className,
+  style: _style,
+  children,
+  preSelectedTab,
+  fullWidth = false,
+  ...rest
+}: TabsProps) => {
   // Internal state for uncontrolled mode
-  const [internalSelectedTab, setInternalSelectedTab] = useState<number>(preSelectedTab || 0);
+  const [internalSelectedTab, setInternalSelectedTab] = useState<number>(
+    preSelectedTab || 0
+  );
 
   // Use controlled or uncontrolled state
-  const selectedTab = isControlled(props) ? props.selected : internalSelectedTab;
-  const setSelectedTab = isControlled(props) ? props.onTabSelect : setInternalSelectedTab;
+  const selectedTab = isControlled(rest) ? rest.selected : internalSelectedTab;
+  const setSelectedTab = isControlled(rest)
+    ? rest.onTabSelect
+    : setInternalSelectedTab;
 
   return (
     <div {...rest}>

--- a/packages/react/src/composite/Tabs/src/Tabs.tsx
+++ b/packages/react/src/composite/Tabs/src/Tabs.tsx
@@ -1,18 +1,30 @@
 import React, { useState } from "react";
 import { tabs } from "@nimbus-ds/styles";
 
-import { TabsProps, TabsComponents } from "./tabs.types";
+import { TabsProps, TabsComponents, ControlledTabsProperties, BaseTabsProperties } from "./tabs.types";
 import { TabsButton, TabsItem } from "./components";
 
-const Tabs: React.FC<TabsProps> & TabsComponents = ({
-  className: _className,
-  style: _style,
-  children,
-  preSelectedTab,
-  fullWidth = false,
-  ...rest
-}: TabsProps) => {
-  const [selectedTab, setSelectedTab] = useState<number>(preSelectedTab || 0);
+const isControlled = (props: BaseTabsProperties | ControlledTabsProperties): props is ControlledTabsProperties => {
+  return 'selected' in props && 'onSelect' in props;
+};
+
+const Tabs: React.FC<TabsProps> & TabsComponents = (props) => {
+  const {
+    className: _className,
+    style: _style,
+    children,
+    preSelectedTab,
+    fullWidth = false,
+    ...rest
+  } = props;
+
+  // Internal state for uncontrolled mode
+  const [internalSelectedTab, setInternalSelectedTab] = useState<number>(preSelectedTab || 0);
+
+  // Use controlled or uncontrolled state
+  const selectedTab = isControlled(props) ? props.selected : internalSelectedTab;
+  const setSelectedTab = isControlled(props) ? props.onTabSelect : setInternalSelectedTab;
+
   return (
     <div {...rest}>
       <ul role="tablist" className={tabs.classnames.container}>

--- a/packages/react/src/composite/Tabs/src/tabs.definitions.ts
+++ b/packages/react/src/composite/Tabs/src/tabs.definitions.ts
@@ -1,3 +1,5 @@
+import { ControlledTabsProperties } from "./tabs.types";
+
 export const generateID = (name: string) =>
   name.toLowerCase().replace(" ", "-");
 
@@ -6,5 +8,5 @@ export const generateID = (name: string) =>
  * @param props - The props of the tabs.
  * @returns True if the tabs are controlled, false otherwise.
  */
-export const isControlled = (props: any) =>
+export const isControlled = (props: any): props is ControlledTabsProperties =>
   "selected" in props && "onTabSelect" in props;

--- a/packages/react/src/composite/Tabs/src/tabs.definitions.ts
+++ b/packages/react/src/composite/Tabs/src/tabs.definitions.ts
@@ -1,2 +1,10 @@
 export const generateID = (name: string) =>
   name.toLowerCase().replace(" ", "-");
+
+/**
+ * Checks if the tabs are controlled.
+ * @param props - The props of the tabs.
+ * @returns True if the tabs are controlled, false otherwise.
+ */
+export const isControlled = (props: any) =>
+  "selected" in props && "onTabSelect" in props;

--- a/packages/react/src/composite/Tabs/src/tabs.docs.json
+++ b/packages/react/src/composite/Tabs/src/tabs.docs.json
@@ -3,7 +3,7 @@
   "name": "Tabs",
   "totalProps": 3,
   "packageName": "@nimbus-ds/tabs",
-  "version": "2.4.0",
+  "version": "2.5.0-rc.1",
   "docLink": "https://nimbus.nuvemshop.com.br/documentation/composite-components/tabs",
   "props": [
     {

--- a/packages/react/src/composite/Tabs/src/tabs.docs.json
+++ b/packages/react/src/composite/Tabs/src/tabs.docs.json
@@ -1,7 +1,7 @@
 {
   "id": "tabs",
   "name": "Tabs",
-  "totalProps": 3,
+  "totalProps": 5,
   "packageName": "@nimbus-ds/tabs",
   "version": "2.5.0-rc.1",
   "docLink": "https://nimbus.nuvemshop.com.br/documentation/composite-components/tabs",
@@ -24,6 +24,20 @@
       "type": "boolean",
       "title": "fullWidth",
       "required": false
+    },
+    {
+      "description": "The currently selected tab index.",
+      "type": "number",
+      "title": "selected",
+      "required": true
+    },
+    {
+      "description": "Callback fired when the selected tab changes.",
+      "type": "object",
+      "additionalProperties": false,
+      "propertyOrder": [],
+      "title": "onTabSelect",
+      "required": true
     }
   ],
   "subComponents": [

--- a/packages/react/src/composite/Tabs/src/tabs.docs.json
+++ b/packages/react/src/composite/Tabs/src/tabs.docs.json
@@ -3,7 +3,7 @@
   "name": "Tabs",
   "totalProps": 5,
   "packageName": "@nimbus-ds/tabs",
-  "version": "2.5.0-rc.1",
+  "version": "2.5.0",
   "docLink": "https://nimbus.nuvemshop.com.br/documentation/composite-components/tabs",
   "props": [
     {

--- a/packages/react/src/composite/Tabs/src/tabs.spec.tsx
+++ b/packages/react/src/composite/Tabs/src/tabs.spec.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 import { Tabs } from "./Tabs";
-import { TabsProps } from "./tabs.types";
+import { TabsProps, ControlledTabsProperties } from "./tabs.types";
 
 const tabContent = "myTabsContent";
 
@@ -51,5 +51,62 @@ describe("GIVEN <Tabs />", () => {
     expect(
       screen.getByRole("tab", { selected: true }).getAttribute("class")
     ).toContain("active");
+  });
+
+  describe("controlled mode", () => {
+    const mockOnTabSelect = jest.fn();
+
+    beforeEach(() => {
+      mockOnTabSelect.mockClear();
+    });
+
+    const renderControlled = (props: Partial<Omit<ControlledTabsProperties, "children">>) => {
+      return render(
+        <Tabs selected={0} onTabSelect={mockOnTabSelect} {...props}>
+          <Tabs.Item label="Tab 1">Content 1</Tabs.Item>
+          <Tabs.Item label="Tab 2">Content 2</Tabs.Item>
+          <Tabs.Item label="Tab 3">Content 3</Tabs.Item>
+        </Tabs>
+      );
+    };
+
+    it("should render with selected tab", () => {
+      renderControlled({ selected: 1 });
+
+      expect(screen.getByText("Content 2")).toBeTruthy();
+      expect(screen.queryByText("Content 1")).toBeNull();
+      expect(screen.queryByText("Content 3")).toBeNull();
+    });
+
+    it("should call onTabSelect when clicking a tab", () => {
+      renderControlled({ selected: 0 });
+
+      fireEvent.click(screen.getByText("Tab 2"));
+      expect(mockOnTabSelect).toHaveBeenCalledWith(1);
+    });
+
+    it("should ignore preSelectedTab in controlled mode", () => {
+      renderControlled({ selected: 1 });
+
+      expect(screen.getByText("Content 2")).toBeTruthy();
+      expect(screen.queryByText("Content 1")).toBeNull();
+    });
+
+    it("should update content when selected prop changes", () => {
+      const { rerender } = renderControlled({ selected: 0 });
+
+      expect(screen.getByText("Content 1")).toBeTruthy();
+
+      rerender(
+        <Tabs selected={1} onTabSelect={mockOnTabSelect}>
+          <Tabs.Item label="Tab 1">Content 1</Tabs.Item>
+          <Tabs.Item label="Tab 2">Content 2</Tabs.Item>
+          <Tabs.Item label="Tab 3">Content 3</Tabs.Item>
+        </Tabs>
+      );
+
+      expect(screen.getByText("Content 2")).toBeTruthy();
+      expect(screen.queryByText("Content 1")).toBeNull();
+    });
   });
 });

--- a/packages/react/src/composite/Tabs/src/tabs.spec.tsx
+++ b/packages/react/src/composite/Tabs/src/tabs.spec.tsx
@@ -60,15 +60,16 @@ describe("GIVEN <Tabs />", () => {
       mockOnTabSelect.mockClear();
     });
 
-    const renderControlled = (props: Partial<Omit<ControlledTabsProperties, "children">>) => {
-      return render(
+    const renderControlled = (
+      props: Partial<Omit<ControlledTabsProperties, "children">>
+    ) =>
+      render(
         <Tabs selected={0} onTabSelect={mockOnTabSelect} {...props}>
           <Tabs.Item label="Tab 1">Content 1</Tabs.Item>
           <Tabs.Item label="Tab 2">Content 2</Tabs.Item>
           <Tabs.Item label="Tab 3">Content 3</Tabs.Item>
         </Tabs>
       );
-    };
 
     it("should render with selected tab", () => {
       renderControlled({ selected: 1 });

--- a/packages/react/src/composite/Tabs/src/tabs.stories.tsx
+++ b/packages/react/src/composite/Tabs/src/tabs.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Box } from "@nimbus-ds/box";
 import { Text } from "@nimbus-ds/text";
@@ -66,5 +66,53 @@ export const basic: Story = {
 export const fullWidth: Story = {
   args: {
     fullWidth: true,
+  },
+};
+
+export const controlled: Story = {
+  render: () => {
+    const [selectedTab, setSelectedTab] = useState(0);
+    const handleSelect = (index: number) => setSelectedTab(index);
+    
+    return (
+      <Tabs selected={selectedTab} onTabSelect={handleSelect}>
+        <Tabs.Item label="Tab 1" labelContent={<Tag>Controlled</Tag>}>
+          <Box
+            borderColor="neutral-interactive"
+            borderStyle="dashed"
+            borderWidth="1"
+            padding="2"
+          >
+            <Text fontSize="base" textAlign="center">
+              Replace me with your controlled tab 1 content
+            </Text>
+          </Box>
+        </Tabs.Item>
+        <Tabs.Item label="Tab 2">
+          <Box
+            borderColor="neutral-interactive"
+            borderStyle="dashed"
+            borderWidth="1"
+            padding="2"
+          >
+            <Text fontSize="base" textAlign="center">
+              Replace me with your controlled tab 2 content
+            </Text>
+          </Box>
+        </Tabs.Item>
+        <Tabs.Item label="Tab 3">
+          <Box
+            borderColor="neutral-interactive"
+            borderStyle="dashed"
+            borderWidth="1"
+            padding="2"
+          >
+            <Text fontSize="base" textAlign="center">
+              Replace me with your controlled tab 3 content
+            </Text>
+          </Box>
+        </Tabs.Item>
+      </Tabs>
+    );
   },
 };

--- a/packages/react/src/composite/Tabs/src/tabs.types.ts
+++ b/packages/react/src/composite/Tabs/src/tabs.types.ts
@@ -7,7 +7,7 @@ export interface TabsComponents {
   Item: typeof TabsItem;
 }
 
-export interface TabsProperties {
+export interface BaseTabsProperties {
   /**
    * The content of the tabs.
    * @TJS-type ReactElement<TabsButtonProps>[];
@@ -24,5 +24,20 @@ export interface TabsProperties {
   fullWidth?: boolean;
 }
 
-export type TabsProps = TabsProperties &
-  Omit<HTMLAttributes<HTMLElement>, "children">;
+export interface ControlledTabsProperties extends BaseTabsProperties {
+  /**
+   * The currently selected tab index.
+   */
+  selected: number;
+  /**
+   * Callback fired when the selected tab changes.
+   */
+  onTabSelect: (index: number) => void;
+  /**
+   * preSelectedTab is not used in controlled mode
+   */
+  preSelectedTab?: never;
+}
+
+export type TabsProps = (BaseTabsProperties | ControlledTabsProperties) &
+  Omit<HTMLAttributes<HTMLDivElement>, "children" | "onSelect">;

--- a/packages/react/src/composite/Tabs/src/tabs.types.ts
+++ b/packages/react/src/composite/Tabs/src/tabs.types.ts
@@ -39,5 +39,10 @@ export interface ControlledTabsProperties extends BaseTabsProperties {
   preSelectedTab?: never;
 }
 
-export type TabsProps = (BaseTabsProperties | ControlledTabsProperties) &
-  Omit<HTMLAttributes<HTMLDivElement>, "children" | "onSelect">;
+export type TabsProps =
+  | (BaseTabsProperties | ControlledTabsProperties) &
+      Omit<HTMLAttributes<HTMLDivElement>, "children" | "onSelect">;
+
+// For docs purposes, we need to merge the two types
+export type TabsProperties = BaseTabsProperties &
+  Omit<ControlledTabsProperties, "preSelectedTab">;


### PR DESCRIPTION
## Type

- [x] New feature 🌈
- [x] Change request 🤓

## Changes proposed ✔️

- `Tabs` component: Adds support for controlled mode, including backward support for uncontrolled support.

https://github.com/user-attachments/assets/f4f8b705-02bc-4b8f-bbe8-91d09878f62a

Closes #226 