### PR TITLE
chore: storybook preview in S3

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -1,4 +1,5 @@
 name: Setup Node and Install Dependencies
+description: "Set Node.js version from .nvmrc and cache/install Yarn dependencies."
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/cleanup-storybook-preview.yml
+++ b/.github/workflows/cleanup-storybook-preview.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           aws-region: us-east-1
-          audience: sts.amazonaws.com 
+          audience: sts.amazonaws.com
 
       - name: Delete Storybook preview from S3
         run: |

--- a/.github/workflows/cleanup-storybook-preview.yml
+++ b/.github/workflows/cleanup-storybook-preview.yml
@@ -1,0 +1,29 @@
+name: cleanup-storybook-preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  id-token: write
+
+jobs:
+  cleanup-s3-preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🔐 Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          aws-region: us-east-1
+          audience: sts.amazonaws.com 
+
+      - name: Delete Storybook preview from S3
+        run: |
+          BUCKET_NAME=ns-ec-dms-bs3-nimbus-preview
+          PR_ID=${{ github.event.pull_request.number }}
+          PREVIEW_PATH="components/pull/$PR_ID"
+
+          echo "Deleting S3 folder: s3://$BUCKET_NAME/$PREVIEW_PATH"
+          aws s3 rm "s3://$BUCKET_NAME/$PREVIEW_PATH" --recursive

--- a/.github/workflows/cleanup-storybook-preview.yml
+++ b/.github/workflows/cleanup-storybook-preview.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           aws-region: us-west-2
-          audience: sts.amazonaws.com 
+          audience: sts.amazonaws.com
 
       - name: Delete Storybook preview from S3
         run: |
@@ -27,4 +27,3 @@ jobs:
 
           echo "Deleting S3 folder: s3://$BUCKET_NAME/$PREVIEW_PATH"
           aws s3 rm "s3://$BUCKET_NAME/$PREVIEW_PATH" --recursive
-`

--- a/.github/workflows/cleanup-storybook-preview.yml
+++ b/.github/workflows/cleanup-storybook-preview.yml
@@ -16,7 +16,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
-          aws-region: us-east-1
+          aws-region: us-west-2
           audience: sts.amazonaws.com 
 
       - name: Delete Storybook preview from S3
@@ -27,3 +27,4 @@ jobs:
 
           echo "Deleting S3 folder: s3://$BUCKET_NAME/$PREVIEW_PATH"
           aws s3 rm "s3://$BUCKET_NAME/$PREVIEW_PATH" --recursive
+`

--- a/.github/workflows/preview-storybook.yml
+++ b/.github/workflows/preview-storybook.yml
@@ -1,4 +1,4 @@
-name: Preview Storybook
+name: "preview-storybook"
 
 on:
   pull_request:
@@ -55,7 +55,7 @@ jobs:
         run: |
           aws s3 sync ./.build-storybook s3://ns-ec-dms-bs3-nimbus-preview/components/pull/${{ github.event.pull_request.number }} --delete
 
-      - name: Comment Storybook preview URL on PR (only if not commented)
+      - name: Comment Storybook preview URL on PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -67,16 +67,18 @@ jobs:
           comments=$(curl -s -H "Authorization: token $GH_TOKEN" \
             https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments)
 
-          already_commented=$(echo "$comments" | jq -r '.[] | select(.body | test("View Storybook.*pull/'"$PR_NUMBER"'"))')
-
-          if [ -z "$already_commented" ]; then
-            echo "No previous Storybook comment found. Posting a new one..."
+          # Encontrar y eliminar el comentario existente si existe
+          comment_id=$(echo "$comments" | jq -r '.[] | select(.body | test("View Storybook.*pull/'"$PR_NUMBER"'")) | .id')
+          
+          if [ ! -z "$comment_id" ]; then
             curl -s -H "Authorization: token $GH_TOKEN" \
-              -H "Content-Type: application/json" \
-              -X POST -d "{
-                \"body\": \"🚀✨ Your Storybook preview is ready!\n\nTake a look at the visual changes introduced in this PR here:  \n🔗 [View Storybook]($STORYBOOK_URL)\n\nHappy reviewing! 🎉\"
-              }" \
-              https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments
-          else
-            echo "Storybook comment already exists. Skipping."
+              -X DELETE \
+              https://api.github.com/repos/$REPO/issues/comments/$comment_id
           fi
+
+          curl -s -H "Authorization: token $GH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -X POST -d "{
+              \"body\": \"🚀✨ Your Storybook preview is ready!\n\nTake a look at the visual changes introduced in this PR here:  \n🔗 <a href=\\\"$STORYBOOK_URL\\\" target=\\\"_blank\\\">View Storybook</a>\n\nHappy reviewing! 🎉\"
+            }" \
+            https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments

--- a/.github/workflows/preview-storybook.yml
+++ b/.github/workflows/preview-storybook.yml
@@ -19,14 +19,12 @@ jobs:
       - name: Check for release files in ./yarn/versions
         id: check_release
         run: |
-          has_releases=$(grep -l "^releases:" .yarn/versions/* 2>/dev/null | wc -l)
-          if [ "$has_releases" -eq "0" ]; then
-            echo "No release files found, skipping..."
-            echo "should_skip=true" >> $GITHUB_OUTPUT
-            echo "## ⚠️ Storybook preview not available" >> $GITHUB_STEP_SUMMARY
-            echo "Storybook preview is not available for this PR because there are no changes available for a new release." >> $GITHUB_STEP_SUMMARY
+          if grep -q "^releases:" .yarn/versions/* 2>/dev/null; then
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
           else
-            echo "should_skip=false" >> $GITHUB_OUTPUT
+            echo "should_skip=true" >> "$GITHUB_OUTPUT"
+            echo "## ⚠️ Storybook preview not available" >> "$GITHUB_STEP_SUMMARY"
+            echo "Storybook preview is not available for this PR because there are no changes available for a new release." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - uses: ./.github/actions/setup-node-deps

--- a/.github/workflows/preview-storybook.yml
+++ b/.github/workflows/preview-storybook.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3    
+        uses: actions/checkout@v3
 
       - name: Check for release files in ./yarn/versions
         id: check_release
@@ -23,6 +23,8 @@ jobs:
           if [ "$has_releases" -eq "0" ]; then
             echo "No release files found, skipping..."
             echo "should_skip=true" >> $GITHUB_OUTPUT
+            echo "## ⚠️ Storybook preview not available" >> $GITHUB_STEP_SUMMARY
+            echo "Storybook preview is not available for this PR because there are no changes available for a new release." >> $GITHUB_STEP_SUMMARY
           else
             echo "should_skip=false" >> $GITHUB_OUTPUT
           fi
@@ -48,14 +50,14 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           aws-region: us-east-1
-          audience: sts.amazonaws.com    
-                  
+          audience: sts.amazonaws.com
+
       - name: Upload Storybook to S3
         if: steps.check_release.outputs.should_skip == 'false'
         run: |
           aws s3 sync ./.build-storybook s3://ns-ec-dms-bs3-nimbus-preview/components/pull/${{ github.event.pull_request.number }} --delete
 
-      - name: Comment Storybook preview URL on PR
+      - name: Comment Storybook preview URL on PR and Check summary
         if: steps.check_release.outputs.should_skip == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +70,6 @@ jobs:
           comments=$(curl -s -H "Authorization: token $GH_TOKEN" \
             https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments)
 
-          # Encontrar y eliminar el comentario existente si existe
           comment_id=$(echo "$comments" | jq -r '.[] | select(.body | test("View Storybook.*pull/'"$PR_NUMBER"'")) | .id')
           
           if [ ! -z "$comment_id" ]; then
@@ -80,6 +81,9 @@ jobs:
           curl -s -H "Authorization: token $GH_TOKEN" \
             -H "Content-Type: application/json" \
             -X POST -d "{
-              \"body\": \"🚀✨ Your Storybook preview is ready!\n\nTake a look at the visual changes introduced in this PR here:  \n🔗 <a href=\\\"$STORYBOOK_URL\\\" target=\\\"_blank\\\">View Storybook</a>\n\nHappy reviewing! 🎉\"
+              \"body\": \"🚀✨ Your Storybook preview is ready!\n\n🔗 [View Storybook]($STORYBOOK_URL)\n\nHappy reviewing! 🎉\"
             }" \
             https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments
+
+          echo "## 🚀 Storybook Preview Ready" >> $GITHUB_STEP_SUMMARY
+          echo "[👉 View Storybook Preview]($STORYBOOK_URL)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/preview-storybook.yml
+++ b/.github/workflows/preview-storybook.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check for release files in ./yarn/versions
         id: check_release
         run: |
-          has_releases=$(grep -l "^releases:" .yarn/versions/* | wc -l)
+          has_releases=$(grep -l "^releases:" .yarn/versions/* 2>/dev/null | wc -l)
           if [ "$has_releases" -eq "0" ]; then
             echo "No release files found, skipping..."
             echo "should_skip=true" >> $GITHUB_OUTPUT
@@ -49,7 +49,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
-          aws-region: us-east-1
+          aws-region: us-west-2
           audience: sts.amazonaws.com
 
       - name: Upload Storybook to S3

--- a/.github/workflows/preview-storybook.yml
+++ b/.github/workflows/preview-storybook.yml
@@ -31,7 +31,7 @@ jobs:
         if: steps.check_release.outputs.should_skip == 'true'
         run: |
           echo "Nothing to build. Exiting workflow."
-          exit 0
+          exit 1
 
       - uses: ./.github/actions/setup-node-deps
 

--- a/.github/workflows/preview-storybook.yml
+++ b/.github/workflows/preview-storybook.yml
@@ -27,24 +27,23 @@ jobs:
             echo "should_skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Exit if no release files
-        if: steps.check_release.outputs.should_skip == 'true'
-        run: |
-          echo "Nothing to build. Exiting workflow."
-          exit 1
-
       - uses: ./.github/actions/setup-node-deps
+        if: steps.check_release.outputs.should_skip == 'false'
 
       - name: Run build tokens
+        if: steps.check_release.outputs.should_skip == 'false'
         run: npm run build:tokens
 
       - name: Run build icons
+        if: steps.check_release.outputs.should_skip == 'false'
         run: yarn build:icons
 
       - name: Build Storybook
+        if: steps.check_release.outputs.should_skip == 'false'
         run: yarn build:storybook
 
       - name: 🔐 Configure AWS credentials using OIDC
+        if: steps.check_release.outputs.should_skip == 'false'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -52,10 +51,12 @@ jobs:
           audience: sts.amazonaws.com    
                   
       - name: Upload Storybook to S3
+        if: steps.check_release.outputs.should_skip == 'false'
         run: |
           aws s3 sync ./.build-storybook s3://ns-ec-dms-bs3-nimbus-preview/components/pull/${{ github.event.pull_request.number }} --delete
 
       - name: Comment Storybook preview URL on PR
+        if: steps.check_release.outputs.should_skip == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-storybook.yml
+++ b/.github/workflows/preview-storybook.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check for release files in ./yarn/versions
         id: check_release
         run: |
-          has_releases=$(grep -lr '^releases:' ./yarn/versions | wc -l)
+          has_releases=$(grep -l "^releases:" .yarn/versions/* | wc -l)
           if [ "$has_releases" -eq "0" ]; then
             echo "No release files found, skipping..."
             echo "should_skip=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -50,11 +50,9 @@ jobs:
       - name: Build Storybook
         run: yarn build:storybook
 
-
-
       - name: Upload Storybook to S3
         run: |
-          aws s3 sync ./storybook-static s3://ns-ec-dms-bs3-nimbus-preview/pull/${{ github.event.pull_request.number }} --delete
+          aws s3 sync ./.build-storybook s3://ns-ec-dms-bs3-nimbus-preview/pull/${{ github.event.pull_request.number }} --delete
 
       - name: Comment Storybook preview URL on PR (only if not commented)
         env:

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -29,13 +29,13 @@ jobs:
           echo "Nothing to build. Exiting workflow."
           exit 0
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
+      - uses: ./.github/actions/setup-node-deps
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Run build tokens
+        run: npm run build:tokens
+
+      - name: Run build icons
+        run: yarn build:icons
 
       - name: Build Storybook
         run: yarn build:storybook

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -10,17 +10,11 @@ jobs:
 
     permissions:
       id-token: write
+      pull-requests: write
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: 🔐 Configure AWS credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
-          aws-region: us-east-1
-          audience: sts.amazonaws.com        
+        uses: actions/checkout@v3    
 
       - name: Check for release files in ./yarn/versions
         id: check_release
@@ -50,6 +44,13 @@ jobs:
       - name: Build Storybook
         run: yarn build:storybook
 
+      - name: 🔐 Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          aws-region: us-east-1
+          audience: sts.amazonaws.com    
+                  
       - name: Upload Storybook to S3
         run: |
           aws s3 sync ./.build-storybook s3://ns-ec-dms-bs3-nimbus-preview/pull/${{ github.event.pull_request.number }} --delete
@@ -59,7 +60,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-          STORYBOOK_URL: https://ns-ec-dms-bs3-nimbus-preview.s3-website-us-west-2.amazonaws.com/pull/${{ github.event.pull_request.number }}/index.html
+          STORYBOOK_URL: https://ns-ec-dms-bs3-nimbus-preview.s3.us-west-2.amazonaws.com/components/pull/${{ github.event.pull_request.number }}/index.html
         run: |
           echo "Checking for existing Storybook comment..."
 

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -12,6 +12,13 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: 🔐 Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ARN_IAM_ROLE }}
+          aws-region: us-east-1
+          audience: sts.amazonaws.com        
+
       - name: Check for release files in ./yarn/versions
         id: check_release
         run: |
@@ -40,12 +47,7 @@ jobs:
       - name: Build Storybook
         run: yarn build:storybook
 
-      - name: 🔐 Configure AWS credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ env.AWS_ARN_IAM_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
-          audience: sts.amazonaws.com
+
 
       - name: Upload Storybook to S3
         run: |

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 🔐 Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ env.AWS_ARN_IAM_ROLE }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           aws-region: us-east-1
           audience: sts.amazonaws.com        
 

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -8,6 +8,9 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -53,7 +53,7 @@ jobs:
                   
       - name: Upload Storybook to S3
         run: |
-          aws s3 sync ./.build-storybook s3://ns-ec-dms-bs3-nimbus-preview/pull/${{ github.event.pull_request.number }} --delete
+          aws s3 sync ./.build-storybook s3://ns-ec-dms-bs3-nimbus-preview/components/pull/${{ github.event.pull_request.number }} --delete
 
       - name: Comment Storybook preview URL on PR (only if not commented)
         env:

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -1,0 +1,78 @@
+name: Preview Storybook
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Check for release files in ./yarn/versions
+        id: check_release
+        run: |
+          has_releases=$(grep -lr '^releases:' ./yarn/versions | wc -l)
+          if [ "$has_releases" -eq "0" ]; then
+            echo "No release files found, skipping..."
+            echo "should_skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Exit if no release files
+        if: steps.check_release.outputs.should_skip == 'true'
+        run: |
+          echo "Nothing to build. Exiting workflow."
+          exit 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build Storybook
+        run: yarn build:storybook
+
+      - name: 🔐 Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ARN_IAM_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+          audience: sts.amazonaws.com
+
+      - name: Upload Storybook to S3
+        run: |
+          aws s3 sync ./storybook-static s3://ns-ec-dms-bs3-nimbus-preview/pull/${{ github.event.pull_request.number }} --delete
+
+      - name: Comment Storybook preview URL on PR (only if not commented)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          STORYBOOK_URL: https://ns-ec-dms-bs3-nimbus-preview.s3-website-us-west-2.amazonaws.com/pull/${{ github.event.pull_request.number }}/index.html
+        run: |
+          echo "Checking for existing Storybook comment..."
+
+          comments=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments)
+
+          already_commented=$(echo "$comments" | jq -r '.[] | select(.body | test("View Storybook.*pull/'"$PR_NUMBER"'"))')
+
+          if [ -z "$already_commented" ]; then
+            echo "No previous Storybook comment found. Posting a new one..."
+            curl -s -H "Authorization: token $GH_TOKEN" \
+              -H "Content-Type: application/json" \
+              -X POST -d "{
+                \"body\": \"🚀✨ Your Storybook preview is ready!\n\nTake a look at the visual changes introduced in this PR here:  \n🔗 [View Storybook]($STORYBOOK_URL)\n\nHappy reviewing! 🎉\"
+              }" \
+              https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments
+          else
+            echo "Storybook comment already exists. Skipping."
+          fi

--- a/.yarn/versions/f602560f.yml
+++ b/.yarn/versions/f602560f.yml
@@ -1,2 +1,2 @@
-releases:
-  - nimbus-design-system: minor
+declined:
+  - nimbus-design-system

--- a/.yarn/versions/f602560f.yml
+++ b/.yarn/versions/f602560f.yml
@@ -1,2 +1,2 @@
-declined:
-  - nimbus-design-system
+releases:
+  - nimbus-design-system: minor

--- a/.yarn/versions/f602560f.yml
+++ b/.yarn/versions/f602560f.yml
@@ -1,0 +1,2 @@
+declined:
+  - nimbus-design-system


### PR DESCRIPTION
## Type

- [x] Tech debt 👩‍💻

## Changes proposed ✔️

This pull request introduces two new GitHub Actions workflows to manage Storybook previews for pull requests. The workflows aim to automate the deployment and cleanup of Storybook previews hosted on S3, improving the developer experience and streamlining the review process.

### New GitHub Actions Workflows

#### Storybook Preview Deployment:
* Added a workflow (`.github/workflows/preview-storybook.yml`) to build and deploy a Storybook preview to an S3 bucket when a pull request is opened, synchronized, or reopened. It includes steps to check for release files, build necessary assets, and upload the preview to S3. **A comment with the preview URL is posted on the pull request only if the PR has a release version**

<img width="928" alt="Screenshot 2025-04-23 at 11 55 55 PM" src="https://github.com/user-attachments/assets/aa487406-45f9-45fd-8832-a5ed44c5d946" />


#### Storybook Preview Cleanup:
* Added a workflow (`.github/workflows/cleanup-storybook-preview.yml`) to delete the Storybook preview from the S3 bucket when a pull request is closed. This ensures that stale previews are removed, saving storage costs.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automatic deployment of Storybook previews for pull requests, providing a unique preview link for each PR.
  - Added automatic cleanup of Storybook preview artifacts from AWS S3 when a pull request is closed.
- **Chores**
  - Integrated new GitHub Actions workflows to manage Storybook preview deployment and cleanup processes.
  - Enhanced GitHub Action metadata with descriptive information for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->