### PR TITLE
fix: thumbnail skeleton

### DIFF
--- a/.yarn/versions/159103fc.yml
+++ b/.yarn/versions/159103fc.yml
@@ -1,3 +1,6 @@
 releases:
   "@nimbus-ds/styles": patch
   "@nimbus-ds/thumbnail": patch
+
+declined:
+  - nimbus-design-system

--- a/.yarn/versions/159103fc.yml
+++ b/.yarn/versions/159103fc.yml
@@ -1,0 +1,3 @@
+releases:
+  "@nimbus-ds/styles": patch
+  "@nimbus-ds/thumbnail": patch

--- a/.yarn/versions/159103fc.yml
+++ b/.yarn/versions/159103fc.yml
@@ -1,6 +1,7 @@
 releases:
   "@nimbus-ds/styles": patch
   "@nimbus-ds/thumbnail": patch
+  "@nimbus-ds/components": patch
 
 declined:
   - nimbus-design-system

--- a/packages/core/styles/CHANGELOG.md
+++ b/packages/core/styles/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Nimbus Styles deprive all styles needed to build nimbus components.
 
-## 2025-04-28 `9.14.1`
+## 2025-05-09 `9.14.1`
 
 #### 🐛 Bug fixes
 

--- a/packages/core/styles/CHANGELOG.md
+++ b/packages/core/styles/CHANGELOG.md
@@ -6,7 +6,7 @@ Nimbus Styles deprive all styles needed to build nimbus components.
 
 #### 🐛 Bug fixes
 
-- `Thumbnail.Skeleton`: `width` support is extended to include percentages and 100% is defined as default, just like `Thumbnail` ([#cc](https://github.com/TiendaNube/nimbus-design-system/pull/xx) by [@harrytiendanube](https://github.com/harrytiendanube))
+- `Thumbnail.Skeleton`: `width` support is extended to include percentages and 100% is defined as default, just like `Thumbnail`. ([Issue](https://github.com/TiendaNube/nimbus-design-system/discussions/248)) ([#289](https://github.com/TiendaNube/nimbus-design-system/pull/289) by [@harrytiendanube](https://github.com/harrytiendanube))
 
 ## 2025-03-25 `9.14.0`
 

--- a/packages/core/styles/CHANGELOG.md
+++ b/packages/core/styles/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus Styles deprive all styles needed to build nimbus components.
 
+## 2025-04-28 `9.14.1`
+
+#### 🐛 Bug fixes
+
+- `Thumbnail.Skeleton`: `width` support is extended to include percentages and 100% is defined as default, just like `Thumbnail` ([#cc](https://github.com/TiendaNube/nimbus-design-system/pull/xx) by [@harrytiendanube](https://github.com/harrytiendanube))
+
 ## 2025-03-25 `9.14.0`
 
 #### 🎉 New features

--- a/packages/core/styles/src/packages/atomic/thumbnail/nimbus-thumbnail.css.ts
+++ b/packages/core/styles/src/packages/atomic/thumbnail/nimbus-thumbnail.css.ts
@@ -10,6 +10,9 @@ export const container = style({
   overflow: "hidden",
   background: varsThemeBase.colors.neutral.surfaceDisabled,
   borderRadius: varsThemeBase.shape.border.radius[2],
+});
+
+export const width = style({
   width: vars.width,
 });
 
@@ -35,6 +38,7 @@ export const styles = {
   container__image,
   container__placeholder,
   skeleton,
+  width,
 };
 
 /* -------------------------------------------------------------------------------------------------

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
-## 2025-05-09 `2.3.3`
+## 2025-04-03 `5.10.1`
 
 #### 🐛 Bug fixes
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
-## 2025-04-03 `5.10.1`
+## 2025-05-09 `5.10.1`
 
 #### 🐛 Bug fixes
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2025-05-09 `2.3.3`
+
+#### 🐛 Bug fixes
+
+- `Thumbnail.Skeleton`: `width` support is extended to include percentages and 100% is defined as default, just like `Thumbnail`. ([Issue](https://github.com/TiendaNube/nimbus-design-system/discussions/248)) ([#289](https://github.com/TiendaNube/nimbus-design-system/pull/289) by [@harrytiendanube](https://github.com/harrytiendanube))
+
+
 ## 2025-04-03 `5.10.0`
 
 #### 🐛 New features

--- a/packages/react/src/atomic/Thumbnail/CHANGELOG.md
+++ b/packages/react/src/atomic/Thumbnail/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The Thumbnail component allows us to present thumbnails of images.
 
+## 2025-04-28 `2.3.2`
+
+#### 🐛 Bug fixes
+
+- `Thumbnail.Skeleton`: `width` support is extended to include percentages and 100% is defined as default, just like `Thumbnail`. ([Issue](https://github.com/TiendaNube/nimbus-design-system/discussions/248)) ([#289](https://github.com/TiendaNube/nimbus-design-system/pull/289) by [@harrytiendanube](https://github.com/harrytiendanube))
+
 ## 2025-03-18 `2.3.1`
 
 ### 💡 Others

--- a/packages/react/src/atomic/Thumbnail/CHANGELOG.md
+++ b/packages/react/src/atomic/Thumbnail/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The Thumbnail component allows us to present thumbnails of images.
 
-## 2025-04-28 `2.3.2`
+## 2025-05-09 `2.3.2`
 
 #### 🐛 Bug fixes
 

--- a/packages/react/src/atomic/Thumbnail/src/Thumbnail.tsx
+++ b/packages/react/src/atomic/Thumbnail/src/Thumbnail.tsx
@@ -18,7 +18,10 @@ const Thumbnail: React.FC<ThumbnailProps> & ThumbnailComponents = ({
   ...rest
 }: ThumbnailProps) => (
   <div
-    className={thumbnail.classnames.container}
+    className={[
+      thumbnail.classnames.container,
+      thumbnail.classnames.width,
+    ].join(" ")}
     style={assignInlineVars({
       [vars.width]: width,
     })}

--- a/packages/react/src/atomic/Thumbnail/src/components/ThumbnailSkeleton/ThumbnailSkeleton.tsx
+++ b/packages/react/src/atomic/Thumbnail/src/components/ThumbnailSkeleton/ThumbnailSkeleton.tsx
@@ -1,20 +1,27 @@
 import React from "react";
-import { thumbnail } from "@nimbus-ds/styles";
+import { thumbnail, vars } from "@nimbus-ds/styles";
 import { Skeleton } from "@nimbus-ds/skeleton";
+import { assignInlineVars } from "@vanilla-extract/dynamic";
 import { ThumbnailSkeletonProps } from "./thumbnailSkeleton.types";
 
 const ThumbnailSkeleton: React.FC<ThumbnailSkeletonProps> = ({
-  width,
+  width = "100%",
   aspectRatio = "1/1",
   "data-testid": dataTestId,
 }) => (
   <div className={thumbnail.classnames.skeleton}>
     <div
       data-testid="thumbnail-skeleton-container"
-      className={thumbnail.sprinkle({ aspectRatio })}
+      className={[
+        thumbnail.sprinkle({ aspectRatio }),
+        thumbnail.classnames.width,
+      ].join(" ")}
+      style={assignInlineVars({
+        [vars.width]: width,
+      })}
     >
       <Skeleton
-        width={width ?? "6.5rem"}
+        width="auto"
         height="100%"
         borderRadius="0.5rem"
         data-testid={dataTestId}

--- a/packages/react/src/atomic/Thumbnail/src/components/ThumbnailSkeleton/thumbnailSkeleton.spec.tsx
+++ b/packages/react/src/atomic/Thumbnail/src/components/ThumbnailSkeleton/thumbnailSkeleton.spec.tsx
@@ -12,10 +12,15 @@ describe("GIVEN <Thumbnail.Skeleton />", () => {
   describe("WHEN rendered", () => {
     it("THEN should render skeleton base", () => {
       makeSut();
-      const skeleton = screen.getByTestId("skeleton-element");
-      expect(skeleton.getAttribute("style")).toMatch(
-        /--width__\w{0,9}: 6.5rem;/
+      const skeletonContainer = screen.getByTestId(
+        "thumbnail-skeleton-container"
       );
+      const skeleton = screen.getByTestId("skeleton-element");
+
+      expect(skeletonContainer.getAttribute("style")).toMatch(
+        /--width__\w{0,9}: 100%;/
+      );
+
       expect(skeleton.getAttribute("style")).toMatch(
         /--height__\w{0,9}: 100%;/
       );

--- a/packages/react/src/atomic/Thumbnail/src/components/ThumbnailSkeleton/thumbnailSkeleton.stories.tsx
+++ b/packages/react/src/atomic/Thumbnail/src/components/ThumbnailSkeleton/thumbnailSkeleton.stories.tsx
@@ -10,4 +10,8 @@ const meta: Meta<typeof Thumbnail.Skeleton> = {
 export default meta;
 type Story = StoryObj<typeof Thumbnail.Skeleton>;
 
-export const basic: Story = { args: {} };
+export const basic: Story = {
+  args: {
+    width: "104px",
+  },
+};

--- a/packages/react/src/atomic/Thumbnail/src/components/ThumbnailSkeleton/thumbnailSkeleton.stories.tsx
+++ b/packages/react/src/atomic/Thumbnail/src/components/ThumbnailSkeleton/thumbnailSkeleton.stories.tsx
@@ -15,3 +15,9 @@ export const basic: Story = {
     width: "104px",
   },
 };
+
+export const percentage: Story = {
+  args: {
+    width: "30%",
+  },
+};

--- a/packages/react/src/atomic/Thumbnail/src/thumbnail.stories.tsx
+++ b/packages/react/src/atomic/Thumbnail/src/thumbnail.stories.tsx
@@ -20,7 +20,7 @@ export const basic: Story = {
   },
 };
 
-export const emnpty: Story = {
+export const empty: Story = {
   args: {
     width: "104px",
   },


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛

## Changes proposed ✔️

- `Thumbnail.Skeleton`: `width` support is extended to include percentages and 100% is defined as default, just like `Thumbnail`. Issue https://github.com/TiendaNube/nimbus-design-system/discussions/248


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The Thumbnail Skeleton component now supports percentage values for its width property, with a default width of 100%, ensuring consistent behavior with the main Thumbnail component.

- **Style**
  - Enhanced styling to enable dynamic width control via CSS variables for Thumbnail and Thumbnail Skeleton components.

- **Documentation**
  - Added changelog entries for versions 9.14.1, 2.3.2, and 5.10.1 documenting the Thumbnail Skeleton width fix.

- **Tests**
  - Updated tests to validate the new width behavior and CSS variable usage in the Thumbnail Skeleton component.

- **Refactor**
  - Fixed a typo in a Storybook story export name.
  - Updated story configurations to demonstrate the new width property, including percentage values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->