### PR TITLE
Fix: styles toast progress

### DIFF
--- a/.yarn/versions/d423fa8c.yml
+++ b/.yarn/versions/d423fa8c.yml
@@ -1,0 +1,6 @@
+releases:
+  "@nimbus-ds/styles": patch
+
+declined:
+  - nimbus-design-system
+  - "@nimbus-ds/stepper"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This is the log of notable changes to the Design System Nimbus that are developer-facing.
 Package-specific changes not released in any package will be added here just before the release. Until then, you can find them in changelogs of the individual packages (see [packages](./packages) directory).
 
+## 2025-08-07
+
+#### 🐛 Bug fixes
+
+- Styles: `Toast` progress variant now uses `neutral.textHigh` background to match Figma. ([#TBD](https://github.com/TiendaNube/nimbus-design-system/pull/TBD) by [@contributor](https://github.com/contributor))
+
 ## 2025-07-29
 
 ### 🎉 New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,6 @@
 This is the log of notable changes to the Design System Nimbus that are developer-facing.
 Package-specific changes not released in any package will be added here just before the release. Until then, you can find them in changelogs of the individual packages (see [packages](./packages) directory).
 
-## 2025-08-07
-
-#### 🐛 Bug fixes
-
-- Styles: `Toast` progress variant now uses `neutral.textHigh` background to match Figma. ([#TBD](https://github.com/TiendaNube/nimbus-design-system/pull/TBD) by [@contributor](https://github.com/contributor))
-
 ## 2025-07-29
 
 ### 🎉 New features

--- a/packages/core/styles/CHANGELOG.md
+++ b/packages/core/styles/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus Styles deprive all styles needed to build nimbus components.
 
+## 2025-08-07 `9.21.2`
+
+#### 🐛 Bug fixes
+
+- `Toast`: Align progress variant background with Figma by using `neutral.textHigh`. ([#TBD](https://github.com/TiendaNube/nimbus-design-system/pull/TBD) by [@contributor](https://github.com/contributor))
+
 ## 2025-08-04 `9.21.1`
 
 #### 🐛 Bug fixes

--- a/packages/core/styles/src/packages/atomic/toast/nimbus-toast.css.ts
+++ b/packages/core/styles/src/packages/atomic/toast/nimbus-toast.css.ts
@@ -48,7 +48,7 @@ export const appearance = styleVariants({
   progress: [
     base,
     {
-      background: varsThemeBase.colors.neutral.textLow,
+      background: varsThemeBase.colors.neutral.textHigh,
     },
   ],
 });


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛
- [ ] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

- Matches Toast progress variant with [Figma](https://www.figma.com/design/TDwgeblsVNeHKKRvoDRk7n/%E2%98%81%EF%B8%8F-Nimbus-v2.0?node-id=6298-186093&t=razwqN7BhX6bpb9T-0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the background color of the Toast component's progress variant to better match the Figma design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->