### PR TITLE
feat: toggle disabled styles

### DIFF
--- a/.yarn/versions/98a204af.yml
+++ b/.yarn/versions/98a204af.yml
@@ -1,0 +1,7 @@
+releases:
+  "@nimbus-ds/styles": patch
+  "@nimbus-ds/toggle": patch
+
+declined:
+  - nimbus-design-system
+  - "@nimbus-ds/stepper"

--- a/.yarn/versions/98a204af.yml
+++ b/.yarn/versions/98a204af.yml
@@ -1,4 +1,5 @@
 releases:
+  "@nimbus-ds/components": patch
   "@nimbus-ds/styles": patch
   "@nimbus-ds/toggle": patch
 

--- a/packages/core/styles/CHANGELOG.md
+++ b/packages/core/styles/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus Styles deprive all styles needed to build nimbus components.
 
+## 2025-08-12 `9.21.2`
+
+#### 🎉 New features
+
+- Added `disabled` state to `Toggle` component. ([#330](https://github.com/TiendaNube/nimbus-design-system/pull/330) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-08-04 `9.21.1`
 
 #### 🐛 Bug fixes

--- a/packages/core/styles/src/packages/atomic/toggle/nimbus-toggle.css.ts
+++ b/packages/core/styles/src/packages/atomic/toggle/nimbus-toggle.css.ts
@@ -87,7 +87,7 @@ globalStyle(`${container} input:checked ~ ${container__slider}:active:before`, {
 
 // Disabled state
 globalStyle(`${container}:has(${container__input}:disabled)`, {
-  cursor: "not-allowed",
+  cursor: "default",
 });
 
 globalStyle(`${container} input:disabled ~ ${container__slider}`, {

--- a/packages/core/styles/src/packages/atomic/toggle/nimbus-toggle.css.ts
+++ b/packages/core/styles/src/packages/atomic/toggle/nimbus-toggle.css.ts
@@ -104,7 +104,7 @@ globalStyle(`${container} input:disabled ~ ${container__slider}:hover:before`, {
   backgroundColor: varsThemeBase.colors.neutral.surfaceHighlight,
 });
 
-// Active + disabled: remove border
+// Checked + disabled: keep non-interactive border color
 globalStyle(`${container} input:checked:disabled ~ ${container__slider}`, {
   borderColor: varsThemeBase.colors.neutral.surfaceDisabled,
 });

--- a/packages/core/styles/src/packages/atomic/toggle/nimbus-toggle.css.ts
+++ b/packages/core/styles/src/packages/atomic/toggle/nimbus-toggle.css.ts
@@ -98,28 +98,8 @@ globalStyle(`${container} input:disabled ~ ${container__slider}`, {
 globalStyle(`${container} input:disabled ~ ${container__slider}:before`, {
   backgroundColor: varsThemeBase.colors.neutral.surfaceHighlight,
 });
-
-globalStyle(`${container} input:disabled ~ ${container__slider}:hover`, {
-  borderColor: varsThemeBase.colors.neutral.interactive,
-});
-
-globalStyle(`${container} input:disabled ~ ${container__slider}:active`, {
-  borderColor: varsThemeBase.colors.neutral.interactive,
-});
-
-globalStyle(
-  `${container} input:disabled ~ ${container__slider}:hover:before`,
-  {
-    backgroundColor: varsThemeBase.colors.neutral.surfaceHighlight,
-  }
-);
-
-globalStyle(
-  `${container} input:disabled ~ ${container__slider}:active:before`,
-  {
-    backgroundColor: varsThemeBase.colors.neutral.surfaceHighlight,
-  }
-);
+ 
+ 
 
 // Active + disabled: remove border
 globalStyle(`${container} input:checked:disabled ~ ${container__slider}`, {

--- a/packages/core/styles/src/packages/atomic/toggle/nimbus-toggle.css.ts
+++ b/packages/core/styles/src/packages/atomic/toggle/nimbus-toggle.css.ts
@@ -98,8 +98,11 @@ globalStyle(`${container} input:disabled ~ ${container__slider}`, {
 globalStyle(`${container} input:disabled ~ ${container__slider}:before`, {
   backgroundColor: varsThemeBase.colors.neutral.surfaceHighlight,
 });
- 
- 
+
+globalStyle(`${container} input:disabled ~ ${container__slider}:hover:before`, {
+  // Reset background color
+  backgroundColor: varsThemeBase.colors.neutral.surfaceHighlight,
+});
 
 // Active + disabled: remove border
 globalStyle(`${container} input:checked:disabled ~ ${container__slider}`, {

--- a/packages/core/styles/src/packages/atomic/toggle/nimbus-toggle.css.ts
+++ b/packages/core/styles/src/packages/atomic/toggle/nimbus-toggle.css.ts
@@ -84,3 +84,44 @@ globalStyle(`${container} input:checked ~ ${container__slider}:hover:before`, {
 globalStyle(`${container} input:checked ~ ${container__slider}:active:before`, {
   backgroundColor: varsThemeBase.colors.neutral.surfaceHighlight,
 });
+
+// Disabled state
+globalStyle(`${container}:has(${container__input}:disabled)`, {
+  cursor: "not-allowed",
+});
+
+globalStyle(`${container} input:disabled ~ ${container__slider}`, {
+  borderColor: varsThemeBase.colors.neutral.interactive,
+  backgroundColor: varsThemeBase.colors.neutral.surfaceDisabled,
+});
+
+globalStyle(`${container} input:disabled ~ ${container__slider}:before`, {
+  backgroundColor: varsThemeBase.colors.neutral.surfaceHighlight,
+});
+
+globalStyle(`${container} input:disabled ~ ${container__slider}:hover`, {
+  borderColor: varsThemeBase.colors.neutral.interactive,
+});
+
+globalStyle(`${container} input:disabled ~ ${container__slider}:active`, {
+  borderColor: varsThemeBase.colors.neutral.interactive,
+});
+
+globalStyle(
+  `${container} input:disabled ~ ${container__slider}:hover:before`,
+  {
+    backgroundColor: varsThemeBase.colors.neutral.surfaceHighlight,
+  }
+);
+
+globalStyle(
+  `${container} input:disabled ~ ${container__slider}:active:before`,
+  {
+    backgroundColor: varsThemeBase.colors.neutral.surfaceHighlight,
+  }
+);
+
+// Active + disabled: remove border
+globalStyle(`${container} input:checked:disabled ~ ${container__slider}`, {
+  borderColor: "transparent",
+});

--- a/packages/core/styles/src/packages/atomic/toggle/nimbus-toggle.css.ts
+++ b/packages/core/styles/src/packages/atomic/toggle/nimbus-toggle.css.ts
@@ -91,7 +91,7 @@ globalStyle(`${container}:has(${container__input}:disabled)`, {
 });
 
 globalStyle(`${container} input:disabled ~ ${container__slider}`, {
-  borderColor: varsThemeBase.colors.neutral.interactive,
+  borderColor: varsThemeBase.colors.neutral.surfaceHighlight,
   backgroundColor: varsThemeBase.colors.neutral.surfaceDisabled,
 });
 
@@ -123,5 +123,5 @@ globalStyle(
 
 // Active + disabled: remove border
 globalStyle(`${container} input:checked:disabled ~ ${container__slider}`, {
-  borderColor: "transparent",
+  borderColor: varsThemeBase.colors.neutral.surfaceDisabled,
 });

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvemshop's team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2025-08-12 `5.17.2`
+
+#### 🐛 Bug fixes
+
+- Added `disabled` state to `Toggle` component. ([#330](https://github.com/TiendaNube/nimbus-design-system/pull/330) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-08-04 `5.17.1`
 
 #### 🐛 Bug fixes

--- a/packages/react/src/atomic/Toggle/CHANGELOG.md
+++ b/packages/react/src/atomic/Toggle/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The Tooltip component allows us to show additional information in a non-intrusive way.
 
+## 2025-08-12 `2.2.3`
+
+### 🐛 Bug fixes
+
+- Added `disabled` state to `Toggle` component. ([#330](https://github.com/TiendaNube/nimbus-design-system/pull/330) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-03-18 `2.2.2`
 
 ### 💡 Others

--- a/packages/react/src/atomic/Toggle/src/Toggle.tsx
+++ b/packages/react/src/atomic/Toggle/src/Toggle.tsx
@@ -12,6 +12,7 @@ const Toggle: React.FC<ToggleProps> & ToggleComponents = ({
   id,
   name,
   active,
+  disabled,
   ...rest
 }: ToggleProps) => (
   <label htmlFor={id || name} className={toggle.classnames.container}>
@@ -22,13 +23,17 @@ const Toggle: React.FC<ToggleProps> & ToggleComponents = ({
       type="checkbox"
       className={toggle.classnames.container__input}
       defaultChecked={active}
+      disabled={disabled}
     />
     <span
       data-testid="slider"
       className={toggle.classnames.container__slider}
     />
     {label && (
-      <Text data-testid="text" color="neutral-textHigh">
+      <Text
+        data-testid="text"
+        color={disabled ? "neutral-textDisabled" : "neutral-textHigh"}
+      >
         {label}
       </Text>
     )}

--- a/packages/react/src/atomic/Toggle/src/Toggle.tsx
+++ b/packages/react/src/atomic/Toggle/src/Toggle.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Text } from "@nimbus-ds/text";
 import { toggle } from "@nimbus-ds/styles";
 
@@ -14,31 +14,36 @@ const Toggle: React.FC<ToggleProps> & ToggleComponents = ({
   active,
   disabled,
   ...rest
-}: ToggleProps) => (
-  <label htmlFor={id || name} className={toggle.classnames.container}>
-    <input
-      {...rest}
-      id={id || name}
-      name={name}
-      type="checkbox"
-      className={toggle.classnames.container__input}
-      defaultChecked={active}
-      disabled={disabled}
-    />
-    <span
-      data-testid="slider"
-      className={toggle.classnames.container__slider}
-    />
-    {label && (
-      <Text
-        data-testid="text"
-        color={disabled ? "neutral-textDisabled" : "neutral-textHigh"}
-      >
-        {label}
-      </Text>
-    )}
-  </label>
-);
+}: ToggleProps) => {
+  const labelColor = useMemo(
+    () => (disabled ? "neutral-textDisabled" : "neutral-textHigh"),
+    [disabled],
+  );
+
+  return (
+    <label htmlFor={id || name} className={toggle.classnames.container}>
+      <input
+        {...rest}
+        id={id || name}
+        name={name}
+        type="checkbox"
+        className={toggle.classnames.container__input}
+        defaultChecked={active}
+        disabled={disabled}
+        aria-disabled={disabled}
+      />
+      <span
+        data-testid="slider"
+        className={toggle.classnames.container__slider}
+      />
+      {label && (
+        <Text data-testid="text" color={labelColor}>
+          {label}
+        </Text>
+      )}
+    </label>
+  );
+};
 
 Toggle.displayName = "Toggle";
 Toggle.Skeleton = ToggleSkeleton;

--- a/packages/react/src/atomic/Toggle/src/toggle.spec.tsx
+++ b/packages/react/src/atomic/Toggle/src/toggle.spec.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { Toggle } from "./Toggle";
 import { ToggleProps } from "./toggle.types";
@@ -15,12 +16,12 @@ describe("GIVEN <Toggle />", () => {
       expect(screen.getByText("My Toggle")).toBeDefined();
     });
 
-    it("THEN should active the toggle correctly", () => {
+    it("THEN should active the toggle correctly", async () => {
       makeSut({ name: "toggle", label: "My Toggle" });
       expect(
         screen.getByTestId<HTMLInputElement>("toggle-input").checked
       ).toBeFalsy();
-      screen.getByText("My Toggle").click();
+      await userEvent.click(screen.getByText("My Toggle"));
       expect(
         screen.getByTestId<HTMLInputElement>("toggle-input").checked
       ).toBeTruthy();
@@ -33,12 +34,12 @@ describe("GIVEN <Toggle />", () => {
       ).toBeTruthy();
     });
 
-    it("THEN should not toggle when disabled", () => {
+    it("THEN should not toggle when disabled", async () => {
       makeSut({ name: "toggle", label: "My Toggle", disabled: true });
       const input = screen.getByTestId<HTMLInputElement>("toggle-input");
       expect(input.disabled).toBeTruthy();
       const label = screen.getByText("My Toggle");
-      fireEvent.click(label);
+      await userEvent.click(label);
       expect(input.checked).toBeFalsy();
     });
   });

--- a/packages/react/src/atomic/Toggle/src/toggle.spec.tsx
+++ b/packages/react/src/atomic/Toggle/src/toggle.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 import { Toggle } from "./Toggle";
 import { ToggleProps } from "./toggle.types";
@@ -31,6 +31,15 @@ describe("GIVEN <Toggle />", () => {
       expect(
         screen.getByTestId<HTMLInputElement>("toggle-input").checked
       ).toBeTruthy();
+    });
+
+    it("THEN should not toggle when disabled", () => {
+      makeSut({ name: "toggle", label: "My Toggle", disabled: true });
+      const input = screen.getByTestId<HTMLInputElement>("toggle-input");
+      expect(input.disabled).toBeTruthy();
+      const label = screen.getByText("My Toggle");
+      fireEvent.click(label);
+      expect(input.checked).toBeFalsy();
     });
   });
 });

--- a/packages/react/src/atomic/Toggle/src/toggle.stories.tsx
+++ b/packages/react/src/atomic/Toggle/src/toggle.stories.tsx
@@ -28,3 +28,18 @@ export const label: Story = {
     label: "Label",
   },
 };
+
+export const disabled: Story = {
+  args: {
+    label: "Disabled",
+    disabled: true,
+  },
+};
+
+export const disabledActive: Story = {
+  args: {
+    label: "Disabled active",
+    disabled: true,
+    active: true,
+  },
+};

--- a/packages/react/src/atomic/Toggle/src/toggle.stories.tsx
+++ b/packages/react/src/atomic/Toggle/src/toggle.stories.tsx
@@ -35,11 +35,3 @@ export const disabled: Story = {
     disabled: true,
   },
 };
-
-export const disabledActive: Story = {
-  args: {
-    label: "Disabled active",
-    disabled: true,
-    active: true,
-  },
-};


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛
- [x] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

- Matches Toggle disabled states with [Figma](https://www.figma.com/design/TDwgeblsVNeHKKRvoDRk7n/%E2%98%81%EF%B8%8F-Nimbus-v2.0?node-id=9088-18109&t=MtwrGwBDZQRNaMwf-0)

@nimbus-ds/styles@9.21.2|patch: Toggle disabled-state styles aligned with Nimbus v2.0 specs.
@nimbus-ds/react@5.17.2|patch: Toggle disabled behavior and visuals aligned with Nimbus v2.0.
@nimbus-ds/toggle@2.2.3|patch: Changelog entry for Toggle disabled state (documentation).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle gains a disabled state with updated non-interactive visuals.
  * Added a Storybook example showcasing the disabled Toggle.

* **Bug Fixes**
  * Toggle no longer changes state when disabled.

* **Tests**
  * Added/updated tests to verify disabled rendering and that user interactions do not toggle it.

* **Documentation**
  * Changelogs updated to document the disabled Toggle release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->