### PR TITLE
chore: remove gap from segmented control options

### DIFF
--- a/.yarn/versions/3b3f89b8.yml
+++ b/.yarn/versions/3b3f89b8.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nimbus-ds/segmented-control": patch

--- a/.yarn/versions/3b3f89b8.yml
+++ b/.yarn/versions/3b3f89b8.yml
@@ -1,2 +1,5 @@
 releases:
   "@nimbus-ds/segmented-control": patch
+
+declined:
+  - nimbus-design-system

--- a/.yarn/versions/3b3f89b8.yml
+++ b/.yarn/versions/3b3f89b8.yml
@@ -1,4 +1,5 @@
 releases:
+  "@nimbus-ds/components": patch
   "@nimbus-ds/segmented-control": patch
 
 declined:

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvemshop's team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2025-09-12 `5.21.2`
+
+#### 💡 Others
+
+- `SegmentedControl`: Removed gap from segmented control options. ([#348](https://github.com/TiendaNube/nimbus-design-system/pull/348) by [@mrolando-tn](https://github.com/mrolando-tn))
+
 ## 2025-09-10 `5.21.1`
 
 #### 💡 Others

--- a/packages/react/src/composite/SegmentedControl/CHANGELOG.md
+++ b/packages/react/src/composite/SegmentedControl/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The SegmentedControl component is a composite component that allows us to select one or more options from a list.
 
+## 2025-09-12 `2.0.2`
+
+#### 💡 Others
+
+- Removed gap between option elements.([#348](https://github.com/TiendaNube/nimbus-design-system/pull/348) by [@mrolando-tn](https://github.com/mrolando-tn))
+
 ## 2025-09-11 `2.0.1`
 
 #### 🐛 Bug fixes

--- a/packages/react/src/composite/SegmentedControl/src/SegmentedControl.tsx
+++ b/packages/react/src/composite/SegmentedControl/src/SegmentedControl.tsx
@@ -117,7 +117,7 @@ const SegmentedControl: React.FC<SegmentedControlProps> &
         {...boxProps}
         // Properties that can't be changed by the consumer
         display="flex"
-        gap="1"
+        gap="none"
         backgroundColor="neutral-surface"
         borderRadius="2"
       >

--- a/packages/react/src/composite/SegmentedControl/src/components/SegmentedControlButton/SegmentedControlButton.stories.tsx
+++ b/packages/react/src/composite/SegmentedControl/src/components/SegmentedControlButton/SegmentedControlButton.stories.tsx
@@ -132,7 +132,7 @@ export const SkeletonState: Story = {
 export const GroupExample: Story = {
   args: {
     children: (
-      <Box display="flex" gap="1" padding="1">
+      <Box display="flex" padding="1">
         <SegmentedControlButton label="Option 1" id="option-1">
           Option 1
         </SegmentedControlButton>
@@ -151,7 +151,7 @@ export const GroupExample: Story = {
 export const FullWidthGroupExample: Story = {
   args: {
     children: (
-      <Box display="flex" gap="1" padding="1" width="100%">
+      <Box display="flex" padding="1" width="100%">
         <SegmentedControlButton label="Option 1" fullWidth id="option-1">
           Option 1
         </SegmentedControlButton>


### PR DESCRIPTION
Removes the gap embedded in each option from the segmented control

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * SegmentedControl options now appear without gaps, creating a tighter, contiguous button group. Visual update only; behavior and interactions remain unchanged.

* **Documentation**
  * Added SegmentedControl changelog entry for version 2.0.2 (2025-09-12) noting the removal of spacing between options and referencing the contributing PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->