### PR TITLE
fix: publish RC WF wasn't building components package

### DIFF
--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -66,6 +66,11 @@ jobs:
           export NODE_OPTIONS="--max_old_space_size=12288"
           yarn build:components
 
+      - name: Build @nimbus-ds/components bundle
+        run: |
+          export NODE_OPTIONS="--max_old_space_size=12288"
+          yarn workspace @nimbus-ds/components build
+
       - name: Build packages
         run: |
           export NODE_OPTIONS="--max_old_space_size=12288"

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -3,11 +3,6 @@ name: publish-rc-manual
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: "Branch to run the workflow from"
-        required: true
-        type: string
-        default: "master"
       packages:
         description: |
           Comma-separated list of packages to publish (e.g., @nimbus-ds/button,@nimbus-ds/box).
@@ -46,8 +41,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.branch }}
 
       - uses: ./.github/actions/setup-node-deps
 

--- a/.yarn/versions/c7bf021e.yml
+++ b/.yarn/versions/c7bf021e.yml
@@ -1,0 +1,2 @@
+declined:
+  - nimbus-design-system


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛
- [ ] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow no longer accepts a selectable branch when manually triggered; workflows will run using the default checkout behavior.
  * Added an extra components build step (with increased Node memory) inserted before package builds to improve build reliability and consistency during releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->