### PR TITLE
feat(Badge): add dot variant and adjust text variant border shape

### DIFF
--- a/.yarn/versions/aa767945.yml
+++ b/.yarn/versions/aa767945.yml
@@ -1,0 +1,11 @@
+releases:
+  "@nimbus-ds/badge": minor
+  "@nimbus-ds/styles": minor
+
+declined:
+  - nimbus-design-system
+  - "@nimbus-ds/button"
+  - "@nimbus-ds/segmented-control"
+  - "@nimbus-ds/split-button"
+  - "@nimbus-ds/stepper"
+  - "@nimbus-ds/time-picker"

--- a/packages/core/styles/src/packages/atomic/badge/nimbus-badge.css.ts
+++ b/packages/core/styles/src/packages/atomic/badge/nimbus-badge.css.ts
@@ -2,18 +2,38 @@ import { style, styleVariants } from "@vanilla-extract/css";
 
 import { varsThemeBase } from "../../../themes";
 
+const baseDot = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+
+  width: "0.5rem", // 0.5rem - 8px
+  height: "0.5rem", // 0.5rem - 8px
+
+  boxSizing: "border-box",
+  borderRadius: varsThemeBase.shape.border.radius.full,
+});
+
+export const dot = styleVariants({
+  primary: [baseDot, { backgroundColor: varsThemeBase.colors.primary.interactive }],
+  success: [baseDot, { backgroundColor: varsThemeBase.colors.success.interactive }],
+  warning: [baseDot, { backgroundColor: varsThemeBase.colors.warning.interactive }],
+  danger: [baseDot, { backgroundColor: varsThemeBase.colors.danger.interactive }],
+  neutral: [baseDot, { backgroundColor: varsThemeBase.colors.neutral.interactive }],
+});
+
 const base = style({
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
 
   width: "fit-content",
-  height: "0.875rem", // 0.875rem - 14px
-  minWidth: "0.875rem", // 0.875rem - 14px
+  height: "1rem", // 1rem - 16px
+  minWidth: "1rem", // 1rem - 16px
 
   padding: `0 ${varsThemeBase.spacing[1]}`,
   boxSizing: "border-box",
-  borderRadius: varsThemeBase.shape.border.radius.full,
+  borderRadius: varsThemeBase.shape.border.radius["1"],
 
   lineHeight: varsThemeBase.lineWeight.body.caption,
   fontSize: varsThemeBase.fontSize.body.caption,

--- a/packages/core/styles/src/packages/atomic/badge/nimbus-badge.css.ts
+++ b/packages/core/styles/src/packages/atomic/badge/nimbus-badge.css.ts
@@ -7,8 +7,8 @@ const baseDot = style({
   alignItems: "center",
   justifyContent: "center",
 
-  width: "0.5rem", // 0.5rem - 8px
-  height: "0.5rem", // 0.5rem - 8px
+  width: varsThemeBase.spacing["2"],
+  height: varsThemeBase.spacing["2"],
 
   boxSizing: "border-box",
   borderRadius: varsThemeBase.shape.border.radius.full,
@@ -28,8 +28,7 @@ const base = style({
   justifyContent: "center",
 
   width: "fit-content",
-  height: "1rem", // 1rem - 16px
-  minWidth: "1rem", // 1rem - 16px
+  minWidth: varsThemeBase.spacing["4"],
 
   padding: `0 ${varsThemeBase.spacing[1]}`,
   boxSizing: "border-box",

--- a/packages/react/src/atomic/Badge/src/Badge.tsx
+++ b/packages/react/src/atomic/Badge/src/Badge.tsx
@@ -10,18 +10,26 @@ const Badge: React.FC<BadgeProps> & BadgeComponents = ({
   style: _style,
   appearance = "neutral",
   theme = "surface",
+  type = "text",
   count,
   ...rest
 }: BadgeProps) => (
   <div
     {...rest}
-    className={[className, badge.classnames[theme][appearance]]
+    className={[
+      className,
+      type === "dot"
+        ? badge.classnames.dot[appearance]
+        : badge.classnames[theme][appearance],
+    ]
       .filter(Boolean)
       .join(" ")}
   >
-    <Text fontSize="caption" lineHeight="caption" color="currentColor">
-      {count}
-    </Text>
+    {type === "text" && (
+      <Text fontSize="caption" lineHeight="caption" color="currentColor">
+        {count}
+      </Text>
+    )}
   </div>
 );
 

--- a/packages/react/src/atomic/Badge/src/Badge.tsx
+++ b/packages/react/src/atomic/Badge/src/Badge.tsx
@@ -16,6 +16,7 @@ const Badge: React.FC<BadgeProps> & BadgeComponents = ({
 }: BadgeProps) => (
   <div
     {...rest}
+    aria-hidden={type === "dot" ? true : undefined}
     className={[
       className,
       type === "dot"

--- a/packages/react/src/atomic/Badge/src/badge.spec.tsx
+++ b/packages/react/src/atomic/Badge/src/badge.spec.tsx
@@ -96,4 +96,46 @@ describe("GIVEN <Badge />", () => {
       ).toContain("light_neutral");
     });
   });
+
+  describe("THEN should correctly render the type dot", () => {
+    it("THEN should correctly render the appearance primary", () => {
+      makeSut({ type: "dot", appearance: "primary" });
+      expect(
+        screen.getByTestId("badge-element").getAttribute("class")
+      ).toContain("dot_primary");
+    });
+
+    it("THEN should correctly render the appearance success", () => {
+      makeSut({ type: "dot", appearance: "success" });
+      expect(
+        screen.getByTestId("badge-element").getAttribute("class")
+      ).toContain("dot_success");
+    });
+
+    it("THEN should correctly render the appearance warning", () => {
+      makeSut({ type: "dot", appearance: "warning" });
+      expect(
+        screen.getByTestId("badge-element").getAttribute("class")
+      ).toContain("dot_warning");
+    });
+
+    it("THEN should correctly render the appearance danger", () => {
+      makeSut({ type: "dot", appearance: "danger" });
+      expect(
+        screen.getByTestId("badge-element").getAttribute("class")
+      ).toContain("dot_danger");
+    });
+
+    it("THEN should correctly render the appearance neutral", () => {
+      makeSut({ type: "dot", appearance: "neutral" });
+      expect(
+        screen.getByTestId("badge-element").getAttribute("class")
+      ).toContain("dot_neutral");
+    });
+
+    it("THEN should not render text content", () => {
+      makeSut({ type: "dot", appearance: "primary" });
+      expect(screen.getByTestId("badge-element")).toBeEmptyDOMElement();
+    });
+  });
 });

--- a/packages/react/src/atomic/Badge/src/badge.spec.tsx
+++ b/packages/react/src/atomic/Badge/src/badge.spec.tsx
@@ -137,5 +137,12 @@ describe("GIVEN <Badge />", () => {
       makeSut({ type: "dot", appearance: "primary" });
       expect(screen.getByTestId("badge-element")).toBeEmptyDOMElement();
     });
+
+    it("THEN should have aria-hidden set to true", () => {
+      makeSut({ type: "dot", appearance: "primary" });
+      expect(
+        screen.getByTestId("badge-element").getAttribute("aria-hidden")
+      ).toBe("true");
+    });
   });
 });

--- a/packages/react/src/atomic/Badge/src/badge.stories.tsx
+++ b/packages/react/src/atomic/Badge/src/badge.stories.tsx
@@ -50,3 +50,38 @@ export const danger: Story = {
     count: "+99",
   },
 };
+
+export const dot: Story = {
+  args: {
+    type: "dot",
+    appearance: "primary",
+  },
+};
+
+export const dotNeutral: Story = {
+  args: {
+    type: "dot",
+    appearance: "neutral",
+  },
+};
+
+export const dotSuccess: Story = {
+  args: {
+    type: "dot",
+    appearance: "success",
+  },
+};
+
+export const dotWarning: Story = {
+  args: {
+    type: "dot",
+    appearance: "warning",
+  },
+};
+
+export const dotDanger: Story = {
+  args: {
+    type: "dot",
+    appearance: "danger",
+  },
+};

--- a/packages/react/src/atomic/Badge/src/badge.types.ts
+++ b/packages/react/src/atomic/Badge/src/badge.types.ts
@@ -14,12 +14,17 @@ export interface BadgeProperties {
   /**
    * Total items to be displayed without badge
    */
-  count: number | string;
+  count?: number | string;
   /**
    * Change the color scheme of the badge.
    * @default surface
    */
   theme?: "surface" | "light";
+  /**
+   * Change the badge type between a text counter and a dot indicator.
+   * @default text
+   */
+  type?: "text" | "dot";
 }
 
 export type BadgeProps = BadgeProperties & HTMLAttributes<HTMLElement>;


### PR DESCRIPTION
## Summary
- Adds `type="dot"` variant: circle 8×8px using `interactive` color tokens, matching Figma spec
- Adjusts text variant border-radius from `full` (pill) to `radius["1"]` (4px) per Figma
- Updates badge height from 14px to 16px per Figma spec
- Makes `count` prop optional to support dot usage without text

## Test plan
- [x] 18 unit tests passing (6 new for dot variant)
- [x] Stories added for all 5 dot appearances (primary, neutral, success, warning, danger)
- [ ] Visual review in Storybook at `Atomic/Badge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Badge gains a new "dot" variant: a small, non-text indicator available in primary, success, warning, danger, and neutral; rendered as decorative (hidden from assistive tech) and does not display the count.
  * Added a prop to switch between text and dot modes (text remains the default).

* **Tests**
  * Added tests covering appearances, empty content, and accessibility behavior for the dot variant.

* **Documentation**
  * Added Storybook examples demonstrating all dot variant options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->