### PR TITLE
ci(sonar): bump sonarqube-scan-action v4 → v6

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn test:ci
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v4
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.yarn/versions/sonarv6.yml
+++ b/.yarn/versions/sonarv6.yml
@@ -1,0 +1,2 @@
+declined:
+  - nimbus-design-system


### PR DESCRIPTION
## Qué cambia

Una línea en `.github/workflows/sonar.yml`:

```diff
-        uses: SonarSource/sonarqube-scan-action@v4
+        uses: SonarSource/sonarqube-scan-action@v6
```

## Por qué

GitHub Actions viene avisando en cada corrida:
- ⚠️ *"This version of the SonarQube Scanner GitHub Action is no longer supported and contains a security vulnerability. Please update to `sonarsource/sonarqube-scan-action@v6`."*
- ⚠️ *"Node.js 20 is deprecated."*

La v6 trae los parches de seguridad y el runtime actualizado, y saca el ruido rojo (`exit code 3`) de las corridas del workflow `sonar.yml`.

## Riesgo: bajo (drop-in)

- La action v6 lee el mismo `sonar-project.properties` (sin cambios).
- Usa los mismos secrets (`SONAR_TOKEN`, `GITHUB_TOKEN`).
- No cambia inputs ni config.

> Nota: `sonar-project.properties` tiene `sonar.qualitygate.wait=true`, así que si después de v6 el scan fallara, sería por el **quality gate** (cobertura/issues), no por la action. SonarCloud no es check requerido, así que de todos modos no bloquea merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality scanning tools to latest versions for improved code analysis and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->