### PR TITLE
chore: declare missing minor release for @nimbus-ds/components

### DIFF
--- a/.yarn/versions/6efeedce.yml
+++ b/.yarn/versions/6efeedce.yml
@@ -1,0 +1,5 @@
+releases:
+  "@nimbus-ds/components": minor
+
+declined:
+  - nimbus-design-system


### PR DESCRIPTION
## Contexto

En #487 (`feat(input): add prefix/suffix text support`) el version file `.yarn/versions/7978f41a.yml` declaró:

```yaml
releases:
  "@nimbus-ds/input": minor
  "@nimbus-ds/styles": minor
```

Faltó `"@nimbus-ds/components": minor`. `@nimbus-ds/components` (`packages/react`) es el paquete agregado que bundlea y re-exporta `Input` desde el código fuente, así que necesita su propio bump para que las props `prefix`/`suffix` lleguen a quienes consumen el paquete agregado.

La release #495 ya se publicó, por lo que `@nimbus-ds/components` quedó en `5.59.0` sin la feature.

## Cambio

Agrega `.yarn/versions/6efeedce.yml` (generado con `yarn workspace @nimbus-ds/components version minor --deferred`) para que la próxima release lo bumpee a `5.60.0`.

`yarn version check` pasa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)