### PR TITLE
docs: warn that version-file-only PRs never publish

### DIFF
--- a/.yarn/versions/a9f99de3.yml
+++ b/.yarn/versions/a9f99de3.yml
@@ -1,0 +1,2 @@
+declined:
+  - nimbus-design-system

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -16,6 +16,11 @@ The easiest way to track changes before raising a PR is to run `yarn bump:check 
 
 Currently also with a gihub action that also validates on each pull request if the versions have changed according to the changes made to the code.
 
+> [!IMPORTANT]
+> A pull request that changes **only** files under `.yarn/versions/` will not publish anything on merge. The `publish-release` workflow lists `.yarn/versions/**`, `**/package.json` and `**/*.docs.json` under `paths-ignore` (so the automated "publish release" commit doesn't retrigger itself), which means such a push to `master` never starts the workflow at all.
+>
+> If you need to add a version bump that was forgotten in an earlier PR, include it alongside a change to a non-ignored path (any source file or doc), or wait for the next code PR to consume the pending version file.
+
 ## 🚀 Publishing Release Candidates (RC)
 
 To publish Release Candidate versions for testing before stable releases:


### PR DESCRIPTION
## Problema

#497 agregó el version file que faltaba para `@nimbus-ds/components` (bump olvidado en #487), pero **al mergear no se publicó nada**.

Causa: `publish-release` tiene `.yarn/versions/**` en `paths-ignore`:

```yaml
# .github/workflows/publish.yml
on:
  push:
    branches: [master]
    paths-ignore:
      - "**/package.json"
      - ".yarn/versions/**"      # ← acá
      - "**/*.docs.json"
```

Como #497 tocó *únicamente* `.yarn/versions/6efeedce.yml`, el push a `master` nunca disparó el workflow. Ese `paths-ignore` está bien puesto — evita que el commit automático *"publish release"* se retrigueree a sí mismo — pero tiene como efecto colateral que un PR de solo-version-file no pueda publicar.

Estado actual de `master`: `.yarn/versions/6efeedce.yml` sigue sin consumir y `@nimbus-ds/components` sigue en `5.59.0` en npm, sin las props `prefix`/`suffix` de #487.

## Cambio

1. Documenta la restricción en `docs/RELEASE_PROCESS.md`, para que quien tenga que agregar un bump olvidado lo acompañe de un path no ignorado.
2. Como este PR toca `docs/` (no ignorado), al mergear **sí** dispara `publish-release`, que consume el version file pendiente y publica `@nimbus-ds/components@5.60.0`.

`.yarn/versions/a9f99de3.yml` declina el workspace raíz para que `yarn version check` pase.

## Nota

`publish.yml` no tiene `workflow_dispatch`, así que hoy no se puede relanzar la publicación a mano cuando pasa esto. Agregarlo sería el arreglo de fondo — queda como seguimiento aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that version-only changes do not publish a release automatically.
  * Documented that version updates must accompany a qualifying code change or await a subsequent release-triggering change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->