### PR TITLE
chore(Repository): teach CodeRabbit that versions are deferred

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -97,9 +97,18 @@ reviews:
         file; the pipeline resolves that to `1.0.0`. Do not ask for `0.0.0` to be changed to
         `1.0.0`, and do not read `0.0.0` as a missing bump.
 
+        EXCEPTION — the one `version` finding worth raising: if the diff itself changes `version`
+        for an EXISTING package (a `-"version": "1.2.0"` / `+"version": "1.3.0"` hunk, i.e. any
+        edit other than the one-time `"0.0.0"` seed on a brand-new package), flag it as a process
+        violation. That bump belongs in `.yarn/versions/*.yml`; hand-editing it here collides with
+        the release pipeline. Ask for the manifest edit to be reverted and the level declared in a
+        version file instead.
+
         The artifact to verify is the `.yarn/versions/*.yml` entry: that the changed package is
         declared, and at the right SemVer level (major for breaking changes, minor for new
-        features, patch for bug fixes).
+        features, patch for bug fixes). Those files sit under a default-excluded path, so their
+        contents are not in the reviewable diff — read them from the repository before concluding
+        that a declaration is missing, and never infer their absence from the diff body alone.
 
         Do review `dependencies` and `peerDependencies` ranges normally.
     - path: "**/packages/react/src/atomic/**/*.{ts,tsx}"
@@ -155,7 +164,8 @@ reviews:
 
           Versions are NEVER bumped in `package.json` in this repo — the release pipeline applies
           them from the deferred version files. Do not look at `package.json` for the bump, and do
-          not ask the author to edit it.
+          not ask the author to edit it. `.yarn/**` is excluded from the reviewable diff by
+          default, so read the version files from the repository rather than from the diff body.
 
           Detect breaking changes by scanning for:
           1. **Props API changes** in *.types.ts: Removed props, renamed props, type narrowing (e.g., `string | number` → `string`), optional→required changes
@@ -199,8 +209,16 @@ reviews:
           (major > minor > patch). Also PASS for the automated release PR (branch
           `release/publish-*`).
 
+          EXCEPTION for a brand-new component package (its `package.json` is added in this PR,
+          seeded with `"version": "0.0.0"`): its `major` is only the seed resolving to `1.0.0`, so
+          `"@nimbus-ds/components": minor` is correct and MUST pass — do not demand `major` to
+          satisfy "at least as high". Adding a component breaks nothing for aggregate consumers.
+          Precedent: #400 (`slider`), #414 (`time-picker`), #319 (`scroll-pane`) and #290
+          (`segmented-control`) all pair the new package's `major` with `components: minor`.
+
           FAIL if: published component source changed and `@nimbus-ds/components` is missing
-          from `releases:`, or is declared at a lower level than a component it ships.
+          from `releases:`, or — outside the new-package exception above — is declared at a lower
+          level than a component it ships.
 
           When failing, quote the version file and the exact line to add, e.g.
           `"@nimbus-ds/components": minor`. Cite the precedent: PR #462 changed Badge without

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -97,12 +97,16 @@ reviews:
         file; the pipeline resolves that to `1.0.0`. Do not ask for `0.0.0` to be changed to
         `1.0.0`, and do not read `0.0.0` as a missing bump.
 
-        EXCEPTION — the one `version` finding worth raising: if the diff itself changes `version`
-        for an EXISTING package (a `-"version": "1.2.0"` / `+"version": "1.3.0"` hunk, i.e. any
-        edit other than the one-time `"0.0.0"` seed on a brand-new package), flag it as a process
-        violation. That bump belongs in `.yarn/versions/*.yml`; hand-editing it here collides with
-        the release pipeline. Ask for the manifest edit to be reverted and the level declared in a
-        version file instead.
+        AUTOMATED RELEASE PR EXCEPTION: if the branch matches `release/publish-*`, `version`
+        changes are the release pipeline applying the deferred declarations and MUST pass. Never
+        report those generated manifest updates as manual edits.
+
+        On every other branch, the one `version` finding worth raising is a diff that changes
+        `version` for an EXISTING package (a `-"version": "1.2.0"` /
+        `+"version": "1.3.0"` hunk, i.e. any edit other than the one-time `"0.0.0"` seed on a
+        brand-new package). Flag it as a process violation: that bump belongs in
+        `.yarn/versions/*.yml`; hand-editing it here collides with the release pipeline. Ask for
+        the manifest edit to be reverted and the level declared in a version file instead.
 
         The artifact to verify is the `.yarn/versions/*.yml` entry: that the changed package is
         declared, and at the right SemVer level (major for breaking changes, minor for new
@@ -209,9 +213,8 @@ reviews:
 
           PASS if: no published component source changed, OR some `.yarn/versions/*.yml` in
           the PR has `"@nimbus-ds/components"` under `releases:` with a bump level at least as
-          high as the highest level declared for any changed component package
-          (major > minor > patch). Also PASS for the automated release PR (branch
-          `release/publish-*`).
+          high as the required level computed below (major > minor > patch). Also PASS for the
+          automated release PR (branch `release/publish-*`).
 
           EXCEPTION for a brand-new component package (its `package.json` is added in this PR,
           seeded with `"version": "0.0.0"`): its `major` is only the seed resolving to `1.0.0`, so
@@ -220,17 +223,17 @@ reviews:
           Precedent: #400 (`slider`), #414 (`time-picker`), #319 (`scroll-pane`) and #290
           (`segmented-control`) all pair the new package's `major` with `components: minor`.
 
-          The exception is scoped to the new packages themselves — apply it by computing the
-          required level from the changed EXISTING component packages only, then requiring
-          `@nimbus-ds/components` to be at least that level (and at least `minor`, since a new
-          component is a feature of the aggregate). So in a MIXED PR — a new package declared
-          `major` alongside an existing component that also needs `major` — the existing
-          component's `major` still governs and `"@nimbus-ds/components": minor` FAILS.
-          `minor` is only correct when every `major` in the PR belongs to a new `0.0.0` package.
+          Compute the required level from the changed EXISTING component packages. If the PR also
+          adds a new component package seeded at `"version": "0.0.0"`, raise that level to at least
+          `minor`, since the new component is a feature of the aggregate. Do not apply this `minor`
+          floor when the PR changes only existing component packages. So in a MIXED PR — a new
+          package declared `major` alongside an existing component that also needs `major` — the
+          existing component's `major` still governs and `"@nimbus-ds/components": minor` FAILS.
+          When the only component change is a new `0.0.0` package, `minor` is correct; when the PR
+          only patches existing components, a matching `patch` on the aggregate is correct.
 
           FAIL if: published component source changed and `@nimbus-ds/components` is missing
-          from `releases:`, or is declared below the level required by the changed existing
-          component packages, or is declared below `minor` at all.
+          from `releases:`, or is declared below the required level computed above.
 
           When failing, quote the version file and the exact line to add, e.g.
           `"@nimbus-ds/components": minor`. Cite the precedent: PR #462 changed Badge without

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -74,8 +74,34 @@ reviews:
         Ensure CHANGELOG.md updates follow the established format: YYYY-MM-DD version with categorized entries (Breaking changes, New features, Bug fixes, Others). 
         Each entry must include PR reference and author, and changes must be properly versioned (major/minor/patch). Changes MUST be documented in their respective package's CHANGELOG.md. 
         **CRITICAL: Clearly highlight and document the package bumps in the summary (or a comment, if unable), following exactly this structure: '@nimbus-ds/<package-name>@<bump-version>|<semver-type>: <Description>.' For example: '@nimbus-ds/styles@9.18.0|minor: Added scroll-pane new composite component...'. It is crucial to respect the requested structure.**
+
+        That bump summary is something YOU produce in the walkthrough. It is never a change
+        requested from the author, and it is never a reason to ask for an edit to `package.json`.
+        Take the package scope verbatim from the version file (`@nimbus-ds/...`) — do not
+        reconstruct it from memory.
+
+        The version in a `CHANGELOG.md` header is the version the release pipeline WILL publish,
+        so it legitimately runs ahead of the `version` in `package.json` on an open PR. Never
+        report that gap as drift; verify the bump level against `.yarn/versions/*.yml` instead.
     - path: "**/package.json"
-      instructions: "Verify version updates follow SemVer: major for breaking changes, minor for new features, patch for bug fixes. Ensure dependencies are properly versioned and peer dependencies are correctly specified."
+      instructions: |
+        NEVER suggest editing the `version` field. Versions in this repo are never bumped in
+        `package.json`: they are declared as deferred files in `.yarn/versions/*.yml` (created by
+        `yarn bump:check --interactive`) and applied by the release pipeline.
+
+        A mismatch between `version` here and the latest header in the package's `CHANGELOG.md`
+        is EXPECTED on an open PR — the pipeline has not run yet. It is NOT a finding. Do not ask
+        for the two to be "synchronized".
+
+        New packages are seeded once with `"version": "0.0.0"` and declare `major` in the version
+        file; the pipeline resolves that to `1.0.0`. Do not ask for `0.0.0` to be changed to
+        `1.0.0`, and do not read `0.0.0` as a missing bump.
+
+        The artifact to verify is the `.yarn/versions/*.yml` entry: that the changed package is
+        declared, and at the right SemVer level (major for breaking changes, minor for new
+        features, patch for bug fixes).
+
+        Do review `dependencies` and `peerDependencies` ranges normally.
     - path: "**/packages/react/src/atomic/**/*.{ts,tsx}"
       instructions: |
         Review atomic components for dependency management in monorepo context:
@@ -124,18 +150,30 @@ reviews:
       - name: "Unversioned Breaking Changes"
         mode: "error"
         instructions: |
-          Pass/fail criteria: All breaking changes MUST have a MAJOR version bump (x.0.0) in package.json.
-          
+          Pass/fail criteria: All breaking changes MUST be declared as `major` for the affected
+          package in a `.yarn/versions/*.yml` file.
+
+          Versions are NEVER bumped in `package.json` in this repo — the release pipeline applies
+          them from the deferred version files. Do not look at `package.json` for the bump, and do
+          not ask the author to edit it.
+
           Detect breaking changes by scanning for:
           1. **Props API changes** in *.types.ts: Removed props, renamed props, type narrowing (e.g., `string | number` → `string`), optional→required changes
           2. **Export removals** in index.ts: Any previously exported symbol (component, type, hook, utility) removed
           3. **Token changes** in packages/core/tokens/src/**/*.json: Removed or renamed token keys
           4. **Default value changes**: Changed defaultProps or default parameter values that alter behavior
           
-          PASS if: No breaking changes detected, OR all breaking changes have corresponding MAJOR version bumps in package.json
-          FAIL if: Breaking changes detected but package.json shows MINOR (0.x.0) or PATCH (0.0.x) bump, or no version bump at all
-          
-          When failing, list each breaking change found and the expected MAJOR version.
+          PASS if: No breaking changes detected, OR every affected package is declared `major` in a
+          `.yarn/versions/*.yml` file
+          FAIL if: Breaking changes detected but the version file declares `minor` or `patch` for
+          that package, or declares nothing for it, or the PR carries no version file at all
+
+          A brand-new package is a special case, not a failure: its `package.json` is seeded with
+          `"version": "0.0.0"` and the version file declares `major`, which the pipeline resolves
+          to `1.0.0`. Adding a new package is not itself a breaking change.
+
+          When failing, quote the version file and the exact line to change, e.g.
+          `"@nimbus-ds/title": major`.
       - name: "Missing @nimbus-ds/components Release"
         mode: "error"
         instructions: |
@@ -228,16 +266,21 @@ reviews:
       - name: "Breaking Change Documentation Verification"
         mode: "error"
         instructions: |
-          Pass/fail criteria: If package.json has MAJOR version bump OR code contains breaking changes, CHANGELOG.md MUST have "#### 🛠 Breaking changes" section.
-          
+          Pass/fail criteria: If a `.yarn/versions/*.yml` declares `major` for a package OR code
+          contains breaking changes, that package's CHANGELOG.md MUST have a
+          "#### 🛠 Breaking changes" section.
+
           Cross-reference:
-          1. Check if any package.json in PR has MAJOR version bump (x.0.0)
+          1. Check if any `.yarn/versions/*.yml` in the PR declares `major` for a package. Never
+             look at `package.json` for this — versions there are applied by the release pipeline,
+             not by the author. A new package seeded at `"version": "0.0.0"` with a `major`
+             declaration is an initial release, so it needs no breaking-changes section.
           2. Check if breaking changes detected in code (props removed, exports removed, tokens changed, CSS modified)
           3. Verify CHANGELOG.md contains "#### 🛠 Breaking changes" or "### 🛠 Breaking changes" section
           4. Verify each breaking change is documented with description and PR reference
           
-          PASS if: No breaking changes and no MAJOR bump, OR breaking changes exist with proper CHANGELOG documentation
-          FAIL if: MAJOR bump without "🛠 Breaking changes" section, OR breaking changes in code without documentation
+          PASS if: No breaking changes and no `major` declaration, OR breaking changes exist with proper CHANGELOG documentation
+          FAIL if: `major` declared for an existing package without a "🛠 Breaking changes" section, OR breaking changes in code without documentation
           
           Documentation format required: "- Description of breaking change. ([#PR](url) by [@author](url))"
   tools:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -203,6 +203,10 @@ reviews:
           that is `*.ts`, `*.tsx` or `*.css.ts`, EXCLUDING `*.spec.tsx`, `*.spec.ts`,
           `*.stories.tsx` and `*.docs.json`, which are not published.
 
+          `.yarn/**` is excluded from the reviewable diff by default, so the version files are
+          not in the diff body. Read them from the repository — never infer the presence, absence
+          or level of a declaration from the diff.
+
           PASS if: no published component source changed, OR some `.yarn/versions/*.yml` in
           the PR has `"@nimbus-ds/components"` under `releases:` with a bump level at least as
           high as the highest level declared for any changed component package
@@ -211,14 +215,22 @@ reviews:
 
           EXCEPTION for a brand-new component package (its `package.json` is added in this PR,
           seeded with `"version": "0.0.0"`): its `major` is only the seed resolving to `1.0.0`, so
-          `"@nimbus-ds/components": minor` is correct and MUST pass — do not demand `major` to
+          it does not raise the required level for the aggregate — do not demand `major` to
           satisfy "at least as high". Adding a component breaks nothing for aggregate consumers.
           Precedent: #400 (`slider`), #414 (`time-picker`), #319 (`scroll-pane`) and #290
           (`segmented-control`) all pair the new package's `major` with `components: minor`.
 
+          The exception is scoped to the new packages themselves — apply it by computing the
+          required level from the changed EXISTING component packages only, then requiring
+          `@nimbus-ds/components` to be at least that level (and at least `minor`, since a new
+          component is a feature of the aggregate). So in a MIXED PR — a new package declared
+          `major` alongside an existing component that also needs `major` — the existing
+          component's `major` still governs and `"@nimbus-ds/components": minor` FAILS.
+          `minor` is only correct when every `major` in the PR belongs to a new `0.0.0` package.
+
           FAIL if: published component source changed and `@nimbus-ds/components` is missing
-          from `releases:`, or — outside the new-package exception above — is declared at a lower
-          level than a component it ships.
+          from `releases:`, or is declared below the level required by the changed existing
+          component packages, or is declared below `minor` at all.
 
           When failing, quote the version file and the exact line to add, e.g.
           `"@nimbus-ds/components": minor`. Cite the precedent: PR #462 changed Badge without
@@ -284,9 +296,13 @@ reviews:
       - name: "Breaking Change Documentation Verification"
         mode: "error"
         instructions: |
-          Pass/fail criteria: If a `.yarn/versions/*.yml` declares `major` for a package OR code
-          contains breaking changes, that package's CHANGELOG.md MUST have a
+          Pass/fail criteria: If a `.yarn/versions/*.yml` declares `major` for an EXISTING package
+          OR code contains breaking changes, that package's CHANGELOG.md MUST have a
           "#### 🛠 Breaking changes" section.
+
+          `.yarn/**` is excluded from the reviewable diff by default, so the version files are not
+          in the diff body. Read them from the repository — never infer the presence, absence or
+          level of a declaration from the diff.
 
           Cross-reference:
           1. Check if any `.yarn/versions/*.yml` in the PR declares `major` for a package. Never
@@ -296,9 +312,21 @@ reviews:
           2. Check if breaking changes detected in code (props removed, exports removed, tokens changed, CSS modified)
           3. Verify CHANGELOG.md contains "#### 🛠 Breaking changes" or "### 🛠 Breaking changes" section
           4. Verify each breaking change is documented with description and PR reference
-          
-          PASS if: No breaking changes and no `major` declaration, OR breaking changes exist with proper CHANGELOG documentation
-          FAIL if: `major` declared for an existing package without a "🛠 Breaking changes" section, OR breaking changes in code without documentation
+
+          PASS if any of:
+          - no breaking changes in code AND no `major` declared;
+          - the only `major` declarations are initial releases of new packages seeded at
+            `"version": "0.0.0"` (no breaking-changes section required for those);
+          - every `major` declared for an existing package AND every breaking change detected in
+            code has the required section, documented in that package's own CHANGELOG.md.
+
+          FAIL if any of:
+          - a `major` is declared for an existing package and that package's CHANGELOG.md has no
+            "🛠 Breaking changes" section;
+          - a breaking change is detected in code and is not documented in that section.
+
+          A mixed PR is judged per package: a new `0.0.0` package needing no section does not
+          excuse a co-changed existing package that does.
           
           Documentation format required: "- Description of breaking change. ([#PR](url) by [@author](url))"
   tools:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -313,20 +313,21 @@ reviews:
           3. Verify CHANGELOG.md contains "#### 🛠 Breaking changes" or "### 🛠 Breaking changes" section
           4. Verify each breaking change is documented with description and PR reference
 
-          PASS if any of:
-          - no breaking changes in code AND no `major` declared;
-          - the only `major` declarations are initial releases of new packages seeded at
-            `"version": "0.0.0"` (no breaking-changes section required for those);
-          - every `major` declared for an existing package AND every breaking change detected in
-            code has the required section, documented in that package's own CHANGELOG.md.
+          Evaluate PER PACKAGE, never over the PR as a whole — an exempt package must not carry
+          the whole PR. A package is "affected" if it has a `major` declaration in a version file
+          or a breaking change detected in its code.
 
-          FAIL if any of:
-          - a `major` is declared for an existing package and that package's CHANGELOG.md has no
-            "🛠 Breaking changes" section;
-          - a breaking change is detected in code and is not documented in that section.
+          PASS if EVERY affected package satisfies one of:
+          - it is a new package seeded at `"version": "0.0.0"` whose `major` is its initial
+            release — no breaking-changes section required; or
+          - it is an existing package, and its own CHANGELOG.md has the required
+            "🛠 Breaking changes" section documenting the change.
 
-          A mixed PR is judged per package: a new `0.0.0` package needing no section does not
-          excuse a co-changed existing package that does.
+          PASS trivially if there is no affected package at all.
+
+          FAIL if ANY affected existing package lacks that section — whether the trigger was its
+          `major` declaration, a breaking change detected in its code, or both. A new `0.0.0`
+          package being exempt never excuses a co-changed existing package.
           
           Documentation format required: "- Description of breaking change. ([#PR](url) by [@author](url))"
   tools:

--- a/.cursor/rules/versioning.mdc
+++ b/.cursor/rules/versioning.mdc
@@ -37,7 +37,8 @@ Do not write `1.0.0` in `package.json` yourself, even though that is the version
 (PR #414): both landed with `0.0.0` in the manifest and `major` in the version file.
 
 Note that `@nimbus-ds/components` takes `minor` here, which is the one case that does **not**
-follow the "at least the highest bump level" rule below. Both bumps are correct: the component's
+follow the "at least the highest bump level" rule below — and only when the new package is the
+sole source of a `major` in the PR. Both bumps are correct: the component's
 `major` only expresses `0.0.0` → `1.0.0`, and adding a component removes nothing from the
 aggregate's API, so consumers of `@nimbus-ds/components` face no break. Every new package in the
 history did it this way — #400, #414, #319 (`scroll-pane`) and #290 (`segmented-control`) all pair
@@ -64,9 +65,19 @@ releases:
 ```
 
 Give `@nimbus-ds/components` **at least the highest bump level** among the changed component
-packages (a `major` on a component means a `major` on `components`) — with the single exception of
-a brand-new package, whose `major` is only the `0.0.0` seed resolving to `1.0.0` and pairs with
-`minor` on the aggregate. See "A brand-new package is seeded at `0.0.0`" above.
+packages (a `major` on a component means a `major` on `components`), counting only **existing**
+packages: a brand-new package's `major` is just the `0.0.0` seed resolving to `1.0.0`, so it does
+not raise the required level. See "A brand-new package is seeded at `0.0.0`" above.
+
+In a **mixed** PR the existing component still governs. Adding a component while breaking another
+one means the aggregate takes `major`, not the `minor` the new package alone would have justified:
+
+```yaml
+releases:
+  "@nimbus-ds/my-component": major # new: 0.0.0 → 1.0.0
+  "@nimbus-ds/title": major # existing: a real breaking change
+  "@nimbus-ds/components": major # governed by Title, not by the new package
+```
 
 ### Why this is not automatic
 

--- a/.cursor/rules/versioning.mdc
+++ b/.cursor/rules/versioning.mdc
@@ -28,15 +28,23 @@ The deferred version file then declares `major`, and the pipeline resolves `0.0.
 
 ```yaml
 releases:
-  "@nimbus-ds/my-component": major
-  "@nimbus-ds/components": major # the aggregate ships the new component's code
+  "@nimbus-ds/my-component": major # 0.0.0 → 1.0.0, the initial release
+  "@nimbus-ds/components": minor # a new component is a feature, not a break
 ```
 
 Do not write `1.0.0` in `package.json` yourself, even though that is the version the initial
 `CHANGELOG.md` entry documents. See `@nimbus-ds/slider` (PR #400) and `@nimbus-ds/time-picker`
-(PR #414): both landed with `0.0.0` in the manifest and `major` in the version file. The `major`
-here is an initial release, not a breaking change, so it needs no
-`#### 🛠 Breaking changes` section.
+(PR #414): both landed with `0.0.0` in the manifest and `major` in the version file.
+
+Note that `@nimbus-ds/components` takes `minor` here, which is the one case that does **not**
+follow the "at least the highest bump level" rule below. Both bumps are correct: the component's
+`major` only expresses `0.0.0` → `1.0.0`, and adding a component removes nothing from the
+aggregate's API, so consumers of `@nimbus-ds/components` face no break. Every new package in the
+history did it this way — #400, #414, #319 (`scroll-pane`) and #290 (`segmented-control`) all pair
+the new package's `major` with `"@nimbus-ds/components": minor`.
+
+For the same reason the `major` needs no `#### 🛠 Breaking changes` section: it is an initial
+release, not a breaking change.
 
 ## Always release `@nimbus-ds/components` alongside a component change
 
@@ -56,7 +64,9 @@ releases:
 ```
 
 Give `@nimbus-ds/components` **at least the highest bump level** among the changed component
-packages (a `major` on a component means a `major` on `components`).
+packages (a `major` on a component means a `major` on `components`) — with the single exception of
+a brand-new package, whose `major` is only the `0.0.0` seed resolving to `1.0.0` and pairs with
+`minor` on the aggregate. See "A brand-new package is seeded at `0.0.0`" above.
 
 ### Why this is not automatic
 

--- a/.cursor/rules/versioning.mdc
+++ b/.cursor/rules/versioning.mdc
@@ -11,6 +11,33 @@ files** in `.yarn/versions/*.yml` (created by `yarn bump:check --interactive`) a
 by the release pipeline. See `.cursor/rules/package-json.mdc` and
 `docs/RELEASE_PROCESS.md`.
 
+The gap this creates is expected: on an open PR the `CHANGELOG.md` header names the version the
+pipeline **will** publish, while `package.json` still holds the previous one. That is not drift —
+never "synchronize" it by hand.
+
+## A brand-new package is seeded at `0.0.0`
+
+Creating a package is the one time you write a `version` by hand, and the only value you ever
+write is the placeholder:
+
+```json
+{ "name": "@nimbus-ds/my-component", "version": "0.0.0" }
+```
+
+The deferred version file then declares `major`, and the pipeline resolves `0.0.0` → `1.0.0`:
+
+```yaml
+releases:
+  "@nimbus-ds/my-component": major
+  "@nimbus-ds/components": major # the aggregate ships the new component's code
+```
+
+Do not write `1.0.0` in `package.json` yourself, even though that is the version the initial
+`CHANGELOG.md` entry documents. See `@nimbus-ds/slider` (PR #400) and `@nimbus-ds/time-picker`
+(PR #414): both landed with `0.0.0` in the manifest and `major` in the version file. The `major`
+here is an initial release, not a breaking change, so it needs no
+`#### 🛠 Breaking changes` section.
+
 ## Always release `@nimbus-ds/components` alongside a component change
 
 `@nimbus-ds/components` (the workspace at `packages/react`) is the aggregate package that

--- a/.yarn/versions/c4f1a70e.yml
+++ b/.yarn/versions/c4f1a70e.yml
@@ -1,0 +1,2 @@
+declined:
+  - nimbus-design-system


### PR DESCRIPTION
## Why

On #502 CodeRabbit [asked](https://github.com/TiendaNube/nimbus-design-system/pull/502#discussion_r3749640871) the author to bump `packages/icons/package.json` from `1.26.0` to `1.27.0` so it would match the CHANGELOG header — the exact hand edit this repo forbids. That PR was already correct: it carried `.yarn/versions/9ae0c629.yml` with `"@nimbus-ds/icons": minor`.

The false positive came from our own config, not from the model. Nothing in `.coderabbit.yaml` mentioned deferred version files, while three instructions asserted the opposite:

| Instruction | Said |
| --- | --- |
| `**/package.json` path instruction | "Verify version updates follow SemVer" — implying the bump lives there |
| `Unversioned Breaking Changes` | "All breaking changes MUST have a MAJOR version bump (x.0.0) in package.json" |
| `Breaking Change Documentation Verification` | "Check if any package.json in PR has MAJOR version bump (x.0.0)" |

So every check hunted for the bump in the one file that never carries it, and read the expected CHANGELOG-vs-manifest gap as drift. A developer or agent following the suggestion — the comment's `🤖 Prompt for AI Agents` block spells out the `package.json` edit — breaks the release flow.

## What changed

- **`**/package.json` instruction** — never suggest editing `version`; the gap against the CHANGELOG is expected on an open PR; verify the `.yarn/versions/*.yml` entry and its level instead. Dependency ranges are still reviewed normally.
- **`**/CHANGELOG.md` instruction** — the `@nimbus-ds/<pkg>@<version>|<type>` bump summary is output CodeRabbit produces, never a change requested from the author, and the scope must be copied verbatim from the version file.
- **`Unversioned Breaking Changes`** — pass/fail now keys on `major` in a version file, not on `x.0.0` in a manifest.
- **`Breaking Change Documentation Verification`** — same, and an initial release is not a breaking change.
- **`.cursor/rules/versioning.mdc`** — documents the `0.0.0` seed (below), which was previously unwritten.

## The new-package case

This is where the old wording failed hardest. A brand-new package is seeded once with `"version": "0.0.0"` and declares `major`; the pipeline resolves it to `1.0.0`. So its manifest reads `0.0.0` while its first CHANGELOG entry reads `1.0.0` — a bigger mismatch than the one flagged on #502, and `0.0.0` also reads as "no bump at all" to the old `Unversioned Breaking Changes` wording.

Verified against the packages that landed this way:

| Package | PR | `version` at creation | Version file | Published |
| --- | --- | --- | --- | --- |
| `@nimbus-ds/slider` | #400 | `0.0.0` | `major` | 1.0.0 |
| `@nimbus-ds/time-picker` | #414 | `0.0.0` | `major` | 1.0.0 |
| `@nimbus-ds/scroll-pane` | #319 | `0.0.0` | `major` | 1.0.0 |
| `@nimbus-ds/segmented-control` | #290 | `0.0.0` | `major` | 1.0.0 |

## Notes

- Config and rules only — no published source touched, so `.yarn/versions/c4f1a70e.yml` declines `nimbus-design-system`, same as #500.
- YAML parses; `yarn bump:check` passes.
- Doesn't fix the thread on #502, which still needs a reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified versioning guidance for new packages, including starting at `0.0.0` and reaching `1.0.0`.
  * Documented how changelog versions may differ from package versions during development.
  * Clarified initial-release breaking-change requirements and aggregate package coordination.

* **Chores**
  * Improved release validation for deferred version declarations and SemVer requirements.
  * Added checks for initial releases, breaking changes, documentation consistency, and permitted component-package release combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-up (46d4ac2a)

- The `0.0.0`-seed example gave `@nimbus-ds/components` a `major`, contradicting all four precedents in the table above — every one of them pairs the new package's `major` with `components: minor`. Corrected, with the reason stated, and the pre-existing "at least the highest bump level" rule now names this as its one exception.
- **That exposed a latent bug**: `Missing @nimbus-ds/components Release` (`error` mode) fails a PR whose `components` level is lower than a component it ships — so it would have rejected every valid new-component PR. Carved out. This predates the branch: none of the four precedents satisfy the rule as written.
- `NEVER suggest editing the version field` was unconditional, silencing the genuine catch (a diff hand-editing `version` on an existing package). Added the carve-out, distinguished from the one-time `0.0.0` seed by the hunk shape.
- `.yarn/**` is outside the reviewable diff by default — this PR's own walkthrough says `excluded by !**/.yarn/**`. Every check now pointed at version files is told to read them from the repository rather than infer absence from the diff body, which is how the #502 false positive got its evidence.
