### PR TITLE
chore(workflows): reusable workflows para nimbus-patterns (Fase 1 y 2)

### DIFF
--- a/.github/workflows/checklist-comment.yml
+++ b/.github/workflows/checklist-comment.yml
@@ -1,6 +1,10 @@
 name: checklist-comment
 
-on: pull_request
+# Runs directly on nimbus-design-system's own pull requests, and is also
+# callable as a reusable workflow from other Nimbus repos (nimbus-patterns).
+on:
+  pull_request:
+  workflow_call:
 
 jobs:
   checklist-comment:

--- a/.github/workflows/checklist-comment.yml
+++ b/.github/workflows/checklist-comment.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   checklist-comment:
     runs-on: ubuntu-latest
+    # A called workflow can never get more than the caller grants (permissions
+    # only narrow, never widen), so this is also what nimbus-patterns' calling
+    # job needs to declare.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/create-github-relase.yml
+++ b/.github/workflows/create-github-relase.yml
@@ -1,6 +1,10 @@
 name: "create-github-relase"
 
-on: workflow_dispatch
+# Runs on manual dispatch inside nimbus-design-system, and is also callable
+# as a reusable workflow from other Nimbus repos (nimbus-patterns).
+on:
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
   create-github-relase:

--- a/.github/workflows/preview-storybook-deploy.yml
+++ b/.github/workflows/preview-storybook-deploy.yml
@@ -1,0 +1,113 @@
+name: "preview-storybook-deploy"
+
+# Generic build → deploy → comment mechanics for a Storybook PR preview,
+# shared by any Nimbus repo. What is repo-specific — deciding *whether* to
+# build (the diff gate) and *what to link to* (per-component deep links) —
+# stays local to each repo's own preview-storybook.yml, which calls this
+# after making that decision.
+on:
+  workflow_call:
+    inputs:
+      s3-prefix:
+        description: >-
+          S3 path segment that namespaces this repo's previews under the
+          shared bucket (e.g. "components" for nimbus-design-system,
+          "patterns" for nimbus-patterns).
+        required: true
+        type: string
+      build-tokens-icons:
+        description: >-
+          Whether to run "build:tokens" and "build:icons" before building
+          Storybook. Only nimbus-design-system needs this — its Storybook
+          renders the tokens/icons packages it owns; nimbus-patterns
+          consumes them as published dependencies instead.
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      AWS_ACCOUNT_ID:
+        required: true
+      AWS_DEPLOY_ROLE:
+        required: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/setup-node-deps
+
+      - name: Run build tokens
+        if: inputs.build-tokens-icons
+        run: npm run build:tokens
+
+      - name: Run build icons
+        if: inputs.build-tokens-icons
+        run: yarn build:icons
+
+      - name: Build Storybook
+        run: yarn build:storybook
+
+      - name: 🔐 Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          aws-region: us-west-2
+          audience: sts.amazonaws.com
+
+      - name: Upload Storybook to S3
+        run: |
+          aws s3 sync ./.build-storybook "s3://ns-ec-dms-bs3-nimbus-preview/${{ inputs.s3-prefix }}/pull/${{ github.event.pull_request.number }}" --delete
+
+      - name: Comment Storybook preview URL on PR and Check summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          STORYBOOK_URL: https://ns-ec-dms-bs3-nimbus-preview.s3.us-west-2.amazonaws.com/${{ inputs.s3-prefix }}/pull/${{ github.event.pull_request.number }}/index.html
+        run: |
+          cat > "$RUNNER_TEMP/preview-comment.md" <<EOF
+          <!-- nimbus-storybook-preview -->
+          🚀✨ Your Storybook preview is ready!
+
+          🔗 [View Storybook]($STORYBOOK_URL)
+
+          Happy reviewing! 🎉
+          EOF
+
+          echo "Checking for existing Storybook comment..."
+
+          # The marker identifies comments written by this workflow; the legacy
+          # "View Storybook...pull/<n>" pattern keeps pull requests commented
+          # before the marker existed from collecting a duplicate. Restricted
+          # to bot authors so a reviewer quoting the preview link can't be
+          # mistaken for the workflow's own comment.
+          if ! comment_ids=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '.[]
+                  | select(.user.type == "Bot")
+                  | select((.body // "") | test("<!-- nimbus-storybook-preview -->")
+                                           or test("View Storybook.*pull/'"$PR_NUMBER"'"))
+                  | .id'); then
+            echo "Could not read the existing comments — posting a new one."
+            comment_ids=""
+          fi
+
+          comment_id=$(printf '%s\n' "$comment_ids" | head -1)
+
+          if [ -n "$comment_id" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$comment_id" \
+              -F "body=@$RUNNER_TEMP/preview-comment.md"
+          else
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+              -F "body=@$RUNNER_TEMP/preview-comment.md"
+          fi
+
+          echo "## 🚀 Storybook Preview Ready" >> "$GITHUB_STEP_SUMMARY"
+          cat "$RUNNER_TEMP/preview-comment.md" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/preview-storybook-deploy.yml
+++ b/.github/workflows/preview-storybook-deploy.yml
@@ -81,9 +81,12 @@ jobs:
           S3_PREFIX: ${{ inputs.s3-prefix }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          # Allowlist, not a blacklist: S3_PREFIX ends up both in the S3 key
+          # and in the HTTPS preview URL, where "." or "#" or "?" carry their
+          # own meaning. Only plain path-segment characters are safe in both.
           case "$S3_PREFIX" in
-            */*|""|*..*)
-              echo "s3-prefix must be a single non-empty path segment, got: '$S3_PREFIX'" >&2
+            *[!A-Za-z0-9-]*|"")
+              echo "s3-prefix must be a non-empty path segment of [A-Za-z0-9-], got: '$S3_PREFIX'" >&2
               exit 1
               ;;
           esac

--- a/.github/workflows/preview-storybook-deploy.yml
+++ b/.github/workflows/preview-storybook-deploy.yml
@@ -34,7 +34,19 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
+    # Two runs on the same PR would race `aws s3 sync --delete` over one
+    # prefix, and could both miss the marker comment and create duplicates.
+    concurrency:
+      group: preview-storybook-deploy-${{ github.repository }}-${{ inputs.s3-prefix }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+
+    # A called workflow can never get more than the caller grants (permissions
+    # only narrow, never widen), so this is also what each caller's job needs
+    # to declare. contents:read is for the checkout step below; id-token:write
+    # is required for the AWS OIDC step and is never part of the default
+    # GITHUB_TOKEN permissions.
     permissions:
+      contents: read
       id-token: write
       pull-requests: write
 
@@ -46,7 +58,7 @@ jobs:
 
       - name: Run build tokens
         if: inputs.build-tokens-icons
-        run: npm run build:tokens
+        run: yarn build:tokens
 
       - name: Run build icons
         if: inputs.build-tokens-icons
@@ -63,8 +75,19 @@ jobs:
           audience: sts.amazonaws.com
 
       - name: Upload Storybook to S3
+        env:
+          # Routed through env (not interpolated directly into the script)
+          # so a caller-controlled input can never expand into shell syntax.
+          S3_PREFIX: ${{ inputs.s3-prefix }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          aws s3 sync ./.build-storybook "s3://ns-ec-dms-bs3-nimbus-preview/${{ inputs.s3-prefix }}/pull/${{ github.event.pull_request.number }}" --delete
+          case "$S3_PREFIX" in
+            */*|""|*..*)
+              echo "s3-prefix must be a single non-empty path segment, got: '$S3_PREFIX'" >&2
+              exit 1
+              ;;
+          esac
+          aws s3 sync ./.build-storybook "s3://ns-ec-dms-bs3-nimbus-preview/$S3_PREFIX/pull/$PR_NUMBER" --delete
 
       - name: Comment Storybook preview URL on PR and Check summary
         env:

--- a/.github/workflows/send-slack-notification.yml
+++ b/.github/workflows/send-slack-notification.yml
@@ -1,6 +1,10 @@
 name: "send-slack-notification"
 
-on: workflow_dispatch
+# Runs on manual dispatch inside nimbus-design-system, and is also callable
+# as a reusable workflow from other Nimbus repos (nimbus-patterns).
+on:
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
   send-slack-notification:

--- a/.github/workflows/send-slack-notification.yml
+++ b/.github/workflows/send-slack-notification.yml
@@ -5,10 +5,21 @@ name: "send-slack-notification"
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      SLACK_WEBHOOK_URL_NIMBUS_UPDATES:
+        required: true
+      SLACK_WEBHOOK_URL_DEPLOYING:
+        required: true
+      SLACK_WEBHOOK_URL_TECH_PRODUCT_UPDATES:
+        required: true
 
 jobs:
   send-slack-notification:
     runs-on: ubuntu-latest
+    # Only needed for the checkout step below; a called workflow can never
+    # get more than the caller grants.
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.yarn/versions/63065d7e.yml
+++ b/.yarn/versions/63065d7e.yml
@@ -1,0 +1,2 @@
+declined:
+  - nimbus-design-system


### PR DESCRIPTION
## Qué cambia

Primer paso del plan de unificación de workflows entre `nimbus-design-system` y `nimbus-patterns`, con este repo como padre. Contexto completo en el plan compartido con el equipo.

**Fase 1 — 3 workflows idénticos, ahora reusables**

`checklist-comment.yml`, `create-github-relase.yml` y `send-slack-notification.yml` eran copiados a mano entre los dos repos. Se les agrega `workflow_call` como trigger adicional (conviven con su trigger directo actual), así `nimbus-patterns` puede consumirlos en vez de mantener su propia copia. Cero cambios de comportamiento para este repo.

**Fase 2 — esqueleto genérico para el preview de Storybook**

Se agrega `preview-storybook-deploy.yml`, un workflow reusable con las partes de build → deploy a S3 → comentario en el PR que son genéricas entre repos, parametrizado por `s3-prefix` y `build-tokens-icons`.

Deliberadamente **no** incluye el gate por diff ni los deep-links por componente (lo que agrega #518): esa lógica depende de la estructura de carpetas de `packages/react/src/{atomic,composite}` y `packages/core/{styles,tokens}`, que `nimbus-patterns` no tiene. Ese preview-storybook.yml de este repo queda sin tocar.

## Cómo se probó

- `actionlint` y `yamllint` sobre los 4 archivos (solo warning preexistente de `checkout@v3`, no relacionado a este cambio).
- Dry-run con `act` para cada trigger (`pull_request`, `workflow_dispatch`, `workflow_call`) de los 3 primeros, y `workflow_call` con inputs reales para `preview-storybook-deploy.yml`.
- `yarn lint`, `yarn types:check`, `yarn test` (117 suites, 1015 tests) vía el pre-push hook local.
- Versión declinada (`.yarn/versions/63065d7e.yml`): esto no toca ningún paquete publicado.

## Para el reviewer

- El PR de `nimbus-patterns` que consume esto apunta temporalmente a la rama `chore/reusable-workflows-phase1` (no a un tag) para poder probarse en CI antes de que este mergee. Una vez mergeado esto, hay que taguear (p. ej. `workflows-v1`) y actualizar la referencia en `nimbus-patterns` antes de mergear ese PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable automation for checklist comments, release creation, and Slack notifications.
  * Added automated Storybook previews for pull requests, with optional token and icon builds.
  * Preview builds are uploaded to cloud storage and linked in pull-request comments.

* **Improvements**
  * Storybook previews support configurable storage locations and secure deployment access.
  * Workflows can run automatically, manually, or be invoked by other workflows.
  * Added clearer workflow access and permission handling for reliable automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->