### PR TITLE
fix(coderabbit): don't treat every CSS touch as a breaking change

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -176,11 +176,15 @@ reviews:
           2. **Export removals** in index.ts: Any previously exported symbol (component, type, hook, utility) removed
           3. **Token changes** in packages/core/tokens/src/**/*.json: Removed or renamed token keys
           4. **Default value changes**: Changed defaultProps or default parameter values that alter behavior
-          5. **CSS breaking changes**, per the "Undocumented CSS Breaking Changes" check below
+          5. **CSS breaking changes**, per items 1-5 of the "Undocumented CSS Breaking Changes"
+             check below — a removed or renamed export/identifier, a removed variant option, a
+             changed `defaultVariants`, or a token reference remapped to a different token
 
           A `*.css.ts` file being touched is never, by itself, a breaking change — only actually
-          matching item 5 above, meaning one of "Undocumented CSS Breaking Changes"'s own six
-          criteria, makes it breaking.
+          matching item 5 above makes it breaking. That check's own item 6 (a layout-affecting
+          value changed with nothing removed or renamed) requires CHANGELOG documentation there,
+          not a MAJOR bump here — whether it should is a separate, not-yet-made call; do not
+          extend item 5 to cover it without that decision.
 
           PASS if: No breaking changes detected, OR every affected package is declared `major` in a
           `.yarn/versions/*.yml` file

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -176,9 +176,11 @@ reviews:
           2. **Export removals** in index.ts: Any previously exported symbol (component, type, hook, utility) removed
           3. **Token changes** in packages/core/tokens/src/**/*.json: Removed or renamed token keys
           4. **Default value changes**: Changed defaultProps or default parameter values that alter behavior
+          5. **CSS breaking changes**, per the "Undocumented CSS Breaking Changes" check below
 
-          A `*.css.ts` file being touched is never, by itself, a breaking change under item 1 or
-          item 4 above — only a removed/renamed export or a changed default matters.
+          A `*.css.ts` file being touched is never, by itself, a breaking change — only actually
+          matching item 5 above, meaning one of "Undocumented CSS Breaking Changes"'s own six
+          criteria, makes it breaking.
 
           PASS if: No breaking changes detected, OR every affected package is declared `major` in a
           `.yarn/versions/*.yml` file
@@ -293,8 +295,16 @@ reviews:
           2. Removed variant options from recipe() (e.g., size: { small, medium, large } → { small, medium })
           3. Renamed CSS class identifiers or CSS variables (--nimbus-*)
           4. Changed defaultVariants in recipe()
-          5. Token reference changes (e.g., vars.colors.primary → vars.colors.brand)
-          
+          5. A token reference deliberately remapped to a semantically different token (e.g.,
+             vars.colors.primary → vars.colors.brand) — replacing a hardcoded value, or an
+             incorrect token, with the token the component's contract already specifies is a
+             conformity fix, not this
+          6. Changed the *value* of an existing layout-affecting declaration — dimensions,
+             display, position, or overflow — on a public component's style, even with no
+             identifier removed or renamed (e.g. height: '32px' → '40px', display: 'block' →
+             'flex'); adding a previously-missing declaration that restores a documented contract
+             is a conformity fix, not this
+
           PASS if: No CSS breaking changes detected, OR all CSS breaking changes are documented in CHANGELOG.md with "🛠 Breaking changes" section
           FAIL if: CSS breaking changes found but CHANGELOG.md lacks documentation or "🛠 Breaking changes" section is missing
           
@@ -321,11 +331,15 @@ reviews:
              "Undocumented CSS Breaking Changes" check above: removed `styleVariants`,
              `recipe`, `globalStyle`, or `createVar` declarations; removed variant options;
              renamed CSS class or CSS variable (`--nimbus-*`) identifiers; a changed
-             `defaultVariants`; or a token reference swapped for a different token. A
-             `*.css.ts` file being touched is never, by itself, a breaking change — e.g. adding
-             a property that was previously implicit or inherited, such as an explicit `height`
-             on an existing style object, removing and renaming nothing, is not breaking.
-             Conversely, a one-line change IS breaking if that line matches any criterion above.
+             `defaultVariants`; a token reference deliberately remapped to a semantically
+             different token; or the *value* of an existing layout-affecting declaration
+             (dimensions, display, position, overflow) changed on a public component's style. A
+             `*.css.ts` file being touched is never, by itself, a breaking change — e.g. adding a
+             property that was previously implicit or inherited, such as an explicit `height` on
+             an existing style object, removing and renaming nothing, is not breaking; nor is
+             replacing a hardcoded value or an incorrect token with the token the component's
+             contract already specifies. Conversely, a one-line change IS breaking if that line
+             matches any criterion above.
           3. Verify CHANGELOG.md contains "#### 🛠 Breaking changes" or "### 🛠 Breaking changes" section
           4. Verify each breaking change is documented with description and PR reference
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -176,7 +176,10 @@ reviews:
           2. **Export removals** in index.ts: Any previously exported symbol (component, type, hook, utility) removed
           3. **Token changes** in packages/core/tokens/src/**/*.json: Removed or renamed token keys
           4. **Default value changes**: Changed defaultProps or default parameter values that alter behavior
-          
+
+          A `*.css.ts` file being touched is never, by itself, a breaking change under item 1 or
+          item 4 above — only a removed/renamed export or a changed default matters.
+
           PASS if: No breaking changes detected, OR every affected package is declared `major` in a
           `.yarn/versions/*.yml` file
           FAIL if: Breaking changes detected but the version file declares `minor` or `patch` for
@@ -313,13 +316,16 @@ reviews:
              not by the author. A new package seeded at `"version": "0.0.0"` with a `major`
              declaration is an initial release, so it needs no breaking-changes section.
           2. Check if breaking changes detected in code: props removed, exports removed, a
-             shared/global token's value changed, or a CSS breaking change per "Undocumented CSS
-             Breaking Changes"'s own definition above (removed style/recipe/variant exports,
-             removed variant options, renamed CSS class/variable identifiers, a changed
-             defaultVariants, or a token reference swapped for a different token). A `*.css.ts`
-             file being touched is never, by itself, a breaking change — e.g. adding an explicit
-             `height` to an existing style object, to fix a component's conformance to an
-             established contract, is not breaking on its own.
+             token key removed or renamed in `packages/core/tokens/src/**/*.json` (per
+             "Unversioned Breaking Changes" item 3), or a CSS breaking change per the
+             "Undocumented CSS Breaking Changes" check above: removed `styleVariants`,
+             `recipe`, `globalStyle`, or `createVar` declarations; removed variant options;
+             renamed CSS class or CSS variable (`--nimbus-*`) identifiers; a changed
+             `defaultVariants`; or a token reference swapped for a different token. A
+             `*.css.ts` file being touched is never, by itself, a breaking change — e.g. adding
+             a property that was previously implicit or inherited, such as an explicit `height`
+             on an existing style object, removing and renaming nothing, is not breaking.
+             Conversely, a one-line change IS breaking if that line matches any criterion above.
           3. Verify CHANGELOG.md contains "#### 🛠 Breaking changes" or "### 🛠 Breaking changes" section
           4. Verify each breaking change is documented with description and PR reference
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -306,8 +306,9 @@ reviews:
           6. Changed the *value* of an existing layout-affecting declaration — dimensions,
              display, position, or overflow — on a public component's style, even with no
              identifier removed or renamed (e.g. height: '32px' → '40px', display: 'block' →
-             'flex'); adding a previously-missing declaration that restores a documented contract
-             is a conformity fix, not this
+             'flex'); adding a previously-missing declaration that restores a documented contract,
+             or correcting a value that drifted from what the component's contract already
+             specifies, is a conformity fix, not this
 
           PASS if: No CSS breaking changes detected, OR all CSS breaking changes are documented in CHANGELOG.md with "🛠 Breaking changes" section
           FAIL if: CSS breaking changes found but CHANGELOG.md lacks documentation or "🛠 Breaking changes" section is missing

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -312,7 +312,14 @@ reviews:
              look at `package.json` for this — versions there are applied by the release pipeline,
              not by the author. A new package seeded at `"version": "0.0.0"` with a `major`
              declaration is an initial release, so it needs no breaking-changes section.
-          2. Check if breaking changes detected in code (props removed, exports removed, tokens changed, CSS modified)
+          2. Check if breaking changes detected in code: props removed, exports removed, a
+             shared/global token's value changed, or a CSS breaking change per "Undocumented CSS
+             Breaking Changes"'s own definition above (removed style/recipe/variant exports,
+             removed variant options, renamed CSS class/variable identifiers, a changed
+             defaultVariants, or a token reference swapped for a different token). A `*.css.ts`
+             file being touched is never, by itself, a breaking change — e.g. adding an explicit
+             `height` to an existing style object, to fix a component's conformance to an
+             established contract, is not breaking on its own.
           3. Verify CHANGELOG.md contains "#### 🛠 Breaking changes" or "### 🛠 Breaking changes" section
           4. Verify each breaking change is documented with description and PR reference
 

--- a/.yarn/versions/320e78a4.yml
+++ b/.yarn/versions/320e78a4.yml
@@ -1,0 +1,3 @@
+declined:
+  - nimbus-design-system
+

--- a/.yarn/versions/320e78a4.yml
+++ b/.yarn/versions/320e78a4.yml
@@ -1,3 +1,2 @@
 declined:
   - nimbus-design-system
-


### PR DESCRIPTION
## Summary

`.coderabbit.yaml`'s "Breaking Change Documentation Verification" check's step 2 flagged
**any** `*.css.ts` modification as a breaking change ("tokens changed, CSS modified"), contradicting
the narrower, correct definition the sibling "Undocumented CSS Breaking Changes" check immediately
above it already uses (removed style/recipe/variant exports, removed variant options, renamed
CSS class/variable identifiers, a changed `defaultVariants`, or a swapped token reference).

This blocked PR [#520](https://github.com/TiendaNube/nimbus-design-system/pull/520) (issue #517,
Select/Select.Skeleton height fix) — a patch-level conformity fix, adding an explicit `height` to
an existing style object, no removed export, no renamed identifier, no changed variant. The
workaround at the time was to document a non-breaking fix as breaking in the CHANGELOG, which
CodeRabbit's own semver-consistency review then flagged as inconsistent with the `patch` version
bump — two automated checks pulling in opposite directions on the same PR.

## Changes proposed

- Step 2 of "Breaking Change Documentation Verification" now restates "Undocumented CSS Breaking
  Changes"'s criteria in full (including `globalStyle`/`createVar` removals, which an earlier
  draft of this fix compressed away) instead of a lossy paraphrase, and instead of pointing at a
  cross-reference that may not resolve at evaluation time — each `custom_checks` entry is
  evaluated from its own `instructions` block in isolation.
- Aligns the token criterion with what "Unversioned Breaking Changes" item 3 actually licenses —
  a token *key* removed or renamed in `packages/core/tokens/src/**/*.json` — instead of a new,
  undefined "shared/global token's value changed" criterion this PR had introduced.
- States explicitly that a `*.css.ts` file being touched is never, by itself, a breaking change,
  with the exact counter-example that caused the problem (adding a previously implicit/inherited
  property, e.g. an explicit `height`) — and closes the loop with an explicit converse: a
  one-line change *is* breaking if it matches any criterion above, so the exemption can't be
  stretched by narrating intent.
- "Undocumented CSS Breaking Changes" also gained a 6th criterion after review: a layout-affecting
  *value* change with nothing removed or renamed (e.g. `height: '32px' → '40px'`) — a real gap the
  original 5 criteria missed, since none of them fire when no identifier moves.
- Mirrors the same "`*.css.ts` touched ≠ breaking" clarification into "Unversioned Breaking
  Changes" (the MAJOR-bump check) — **but deliberately stops at the sibling check's item 5, not
  item 6.** A layout-value change now requires CHANGELOG documentation (item 6, above) but not a
  MAJOR bump. Whether it should require one too is a real, separate policy question — this PR
  does not answer it, and item 5 here says explicitly not to extend to item 6 without that
  decision being made on purpose, not as a side effect of closing the documentation gap.
- Includes `.yarn/versions/320e78a4.yml` declining a release for the root workspace — this PR
  only touches process config, no package source.

## Related

- Jira: [ONB-1172](https://tiendanube.atlassian.net/browse/ONB-1172)
- Root cause: `nimbus-design-system#517`, PR #520
- Companion PR in `nimbus-patterns` (same fix, ported in full — that repo now carries its own
  "Undocumented CSS Breaking Changes" check instead of paraphrasing this one, and its
  "Unversioned Breaking Changes" gains the same CSS item, with the same item-6 carve-out):
  TiendaNube/nimbus-patterns#190
- Follow-up (not in this PR, different kind of risk — build/release logic, not config text):
  [ONB-1179](https://tiendanube.atlassian.net/browse/ONB-1179) — `.scripts/build-packages.ts`
  reads only the first `.yarn/versions/*.yml` alphabetically, which this PR's own
  `320e78a4.yml` could silently starve a future PR's real release out of a build. Applies to
  `nimbus-patterns` too — same `paths[0]` pattern there.

## Test plan

- [ ] Confirm the restated criteria still catch a real breaking CSS change (removed export,
      renamed class, changed variant, removed variant option) — should still fail.
- [ ] Confirm a non-breaking touch (explicit `height` added, nothing removed/renamed) does not
      require a `🛠 Breaking changes` section — should now pass.
- [ ] Confirm a layout-*value* change (e.g. `height: '32px'` → `'40px'`, nothing removed/renamed)
      requires CHANGELOG documentation but does **not** require a MAJOR version bump.
- [ ] `yarn version check` passes (verified locally before pushing).

🤖 Generated with [Claude Code](https://claude.ai/code)


[ONB-1172]: https://tiendanube.atlassian.net/browse/ONB-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved breaking-change detection for styling updates, including CSS-in-TypeScript changes.
  * Added clearer checks for removed or renamed style variants, changed defaults, token remapping, and layout-affecting values.
  * Excluded routine styling additions, token corrections, and conformity fixes from breaking-change assessments.
* **Documentation**
  * Updated documentation verification to use the same detailed styling-change criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->