### PR TITLE
test(playground): validate disposable prototype flow

### DIFF
--- a/packages/react/src/prototypes/PlaygroundSmoke/PlaygroundSmoke.tsx
+++ b/packages/react/src/prototypes/PlaygroundSmoke/PlaygroundSmoke.tsx
@@ -1,0 +1,74 @@
+import React, { useCallback, useState } from "react";
+import { Box } from "@nimbus-ds/box";
+import { Button } from "@nimbus-ds/button";
+import { Card } from "@nimbus-ds/card";
+import { Tag } from "@nimbus-ds/tag";
+import { Text } from "@nimbus-ds/text";
+import { Title } from "@nimbus-ds/title";
+
+interface PlaygroundSmokeProps {
+  fullScreen?: boolean;
+  initialConfirmed?: boolean;
+}
+
+export const PlaygroundSmoke: React.FC<PlaygroundSmokeProps> = ({
+  fullScreen = false,
+  initialConfirmed = false,
+}) => {
+  const [confirmed, setConfirmed] = useState(initialConfirmed);
+
+  const handleConfirm = useCallback(() => setConfirmed(true), []);
+  const handleReset = useCallback(() => setConfirmed(false), []);
+
+  return (
+    <Box
+      alignItems="center"
+      backgroundColor="neutral-surface"
+      display="flex"
+      justifyContent="center"
+      minHeight={fullScreen ? "100vh" : "32rem"}
+      padding="4"
+      width="100%"
+    >
+      <Box maxWidth="30rem" width="100%">
+        <Card padding="none">
+          <Card.Header padding="base">
+            <Box
+              alignItems="center"
+              display="flex"
+              justifyContent="space-between"
+            >
+              <Title as="h3">
+                {confirmed ? "Prototype complete" : "Review mock order"}
+              </Title>
+              <Tag appearance="neutral">Mock data</Tag>
+            </Box>
+          </Card.Header>
+          <Card.Body padding="base">
+            <Box display="flex" flexDirection="column" gap="2">
+              <Text fontWeight="bold">Nimbus notebook</Text>
+              <Text color="neutral-textLow">Quantity: 1 · Total: $24.00</Text>
+              <Box aria-live="polite">
+                <Text>
+                  {confirmed
+                    ? "The simulated order was confirmed. No data was sent or persisted."
+                    : "Confirm the order to verify that state transitions work in both preview surfaces."}
+                </Text>
+              </Box>
+            </Box>
+          </Card.Body>
+          <Card.Footer padding="base">
+            <Button
+              appearance={confirmed ? "neutral" : "primary"}
+              onClick={confirmed ? handleReset : handleConfirm}
+            >
+              {confirmed ? "Start again" : "Confirm mock order"}
+            </Button>
+          </Card.Footer>
+        </Card>
+      </Box>
+    </Box>
+  );
+};
+
+PlaygroundSmoke.displayName = "PlaygroundSmoke";

--- a/packages/react/src/prototypes/PlaygroundSmoke/playgroundSmoke.stories.tsx
+++ b/packages/react/src/prototypes/PlaygroundSmoke/playgroundSmoke.stories.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { PlaygroundSmoke } from "./PlaygroundSmoke";
+
+const meta: Meta<typeof PlaygroundSmoke> = {
+  title: "Prototypes/Playground smoke",
+  component: PlaygroundSmoke,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PlaygroundSmoke>;
+
+export const Playground: Story = {
+  args: {
+    initialConfirmed: false,
+  },
+};
+
+export const FullScreen: Story = {
+  name: "Full screen",
+  args: {
+    fullScreen: true,
+    initialConfirmed: false,
+  },
+  parameters: {
+    layout: "fullscreen",
+    controls: {
+      disable: true,
+    },
+  },
+};


### PR DESCRIPTION
> [!IMPORTANT]
> This is a disposable Nimbus prototype. Keep this pull request in draft and
> close it without merging after preserving the outcome.

## Intention

**What should someone be able to do?**

Create a prototype in Nimbus Core and receive both a Storybook working link and a direct Full screen link without adding a publishable package.

**Who would use it, and in which situation?**

Nimbus designers and developers validating an uncertain interaction before deciding its formal destination.

**What question should this prototype help answer?**

Does the proposed Playground workflow render a package-composed interaction, preserve its state transition in both preview surfaces, and remain isolated from formal contribution gates?

**Owner or contact:** ONB-1176 owner

## What to try

1. Open the `Playground` link and click **Confirm mock order**.
2. Confirm that the view changes to **Prototype complete**.
3. Click **Start again**.
4. Repeat the interaction in the `Full screen` link at desktop and mobile widths.

## Simulated parts and limitations

- Product, quantity, and price are hardcoded mock data.
- Confirmation uses local React state only.
- No backend request, persistence, authentication, checkout, or product routing exists.
- The visual content exists only to exercise Nimbus composition and the preview workflow.

## Observations and evidence

- Local Storybook generated `prototypes-playground-smoke--playground` and `prototypes-playground-smoke--full-screen` from `index.json`.
- The preview-link command produced the expected manager and `iframe.html` URLs.
- The Full screen interaction completed successfully in the local browser.
- At a 390 x 844 viewport, the action remained visible and the document had no horizontal overflow.
- The remote preview comment published both required links:
  - [Playground](https://ns-ec-dms-bs3-nimbus-preview.s3.us-west-2.amazonaws.com/components/pull/526/index.html?path=/story/prototypes-playground-smoke--playground)
  - [Full screen](https://ns-ec-dms-bs3-nimbus-preview.s3.us-west-2.amazonaws.com/components/pull/526/iframe.html?id=prototypes-playground-smoke--full-screen&viewMode=story)
- Both remote surfaces rendered the expected prototype. Clicking **Confirm mock order** in Full screen changed the state to **Prototype complete**, with **Start again** available.
- Prototype-only workflow behavior is visible in this PR: the checklist job is skipped, while Storybook deployment, SonarCloud, and security complete normally.
- Preview cleanup remains to be verified when this PR is closed without merging.

Tracking: [ONB-1176](https://tiendanube.atlassian.net/browse/ONB-1176)  
Enabler: [PR #525](https://github.com/TiendaNube/nimbus-design-system/pull/525)

## Outcome

- [x] Still exploring
- [ ] Discard
- [ ] Start a materially different exploration
- [ ] Formal handoff
- [ ] Expired after 30 days without activity

**Why this outcome?**

The local and remote mechanisms work. The smoke exploration remains open only until CI and preview cleanup can be verified; it will not be merged.

**Follow-up link, when applicable:** [ONB-1176](https://tiendanube.atlassian.net/browse/ONB-1176)

## Closure

- [x] The outcome remains understandable after the preview disappears.
- [x] Mocked, hardcoded, and simulated behavior is documented.
- [x] No secrets, personal data, customer data, or confidential information was used.
- [x] This pull request will be closed without merging.


[ONB-1176]: https://tiendanube.atlassian.net/browse/ONB-1176
