### PR TITLE
prototype(progress-ring): does a ring read better than the linear bar?

### DIFF
--- a/packages/react/src/prototypes/ProgressRing/ProgressRing.tsx
+++ b/packages/react/src/prototypes/ProgressRing/ProgressRing.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+
+/**
+ * Disposable prototype. Mirrors the public surface of `@nimbus-ds/progress-bar`
+ * on purpose: the open question is whether the ring shape reads better in a
+ * tight space with a value at its centre, not what a new API should look like.
+ */
+export type ProgressRingAppearance =
+  | "primary"
+  | "success"
+  | "warning"
+  | "danger"
+  | "neutral"
+  | "ai-generative";
+
+export interface ProgressRingProps {
+  /** Progress value from 0 to 100. */
+  value: number;
+  /** Same appearance set as ProgressBar. */
+  appearance?: ProgressRingAppearance;
+  /** Outer diameter in pixels. */
+  size?: number;
+  /** Ring thickness in pixels. */
+  thickness?: number;
+  /** Content at the centre. Defaults to the rounded percentage. */
+  children?: React.ReactNode;
+  /** Accessible name, since the centre label alone is not one. */
+  label?: string;
+}
+
+/**
+ * `ai-generative` has no single `interactive` token — ProgressBar paints it with
+ * a gradient. The ring falls back to the primary token, which is one of the
+ * things this prototype fakes.
+ */
+const strokeFor = (appearance: ProgressRingAppearance): string =>
+  appearance === "ai-generative"
+    ? "var(--nimbus-colors-primary-interactive)"
+    : `var(--nimbus-colors-${appearance}-interactive)`;
+
+export const ProgressRing: React.FC<ProgressRingProps> = ({
+  value,
+  appearance = "neutral",
+  size = 96,
+  thickness = 8,
+  children,
+  label,
+}) => {
+  const clamped = Math.min(100, Math.max(0, value));
+  const radius = (size - thickness) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const centre = size / 2;
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={Math.round(clamped)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={label ?? "Progress"}
+      style={{
+        position: "relative",
+        width: size,
+        height: size,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <svg width={size} height={size} style={{ transform: "rotate(-90deg)" }}>
+        <circle
+          cx={centre}
+          cy={centre}
+          r={radius}
+          fill="none"
+          strokeWidth={thickness}
+          stroke="var(--nimbus-colors-neutral-surfaceDisabled)"
+        />
+        <circle
+          cx={centre}
+          cy={centre}
+          r={radius}
+          fill="none"
+          strokeWidth={thickness}
+          stroke={strokeFor(appearance)}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={circumference * (1 - clamped / 100)}
+          style={{ transition: "stroke-dashoffset 320ms ease" }}
+        />
+      </svg>
+      <div style={{ position: "absolute", textAlign: "center" }}>
+        {children ?? (
+          <span
+            style={{
+              fontFamily: "var(--nimbus-fontFamily-sans)",
+              fontSize: `${Math.max(11, Math.round(size / 5))}px`,
+              fontWeight: 600,
+              color: "var(--nimbus-colors-neutral-textHigh)",
+            }}
+          >
+            {Math.round(clamped)}%
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/react/src/prototypes/ProgressRing/progressRing.stories.tsx
+++ b/packages/react/src/prototypes/ProgressRing/progressRing.stories.tsx
@@ -1,0 +1,178 @@
+import React, { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Box } from "@nimbus-ds/box";
+import { Text } from "@nimbus-ds/text";
+import { Title } from "@nimbus-ds/title";
+import { Card } from "@nimbus-ds/card";
+import { Checkbox } from "@nimbus-ds/checkbox";
+import { ProgressBar } from "@nimbus-ds/progress-bar";
+
+import { ProgressRing } from "./ProgressRing";
+
+const meta: Meta<typeof ProgressRing> = {
+  title: "Prototypes/ProgressRing",
+  component: ProgressRing,
+};
+
+export default meta;
+
+/** Internal working view: sweep the values and compare against the linear bar. */
+export const Playground: StoryObj<typeof ProgressRing> = {
+  argTypes: {
+    value: { control: { type: "range", min: 0, max: 100, step: 1 } },
+    size: { control: { type: "range", min: 24, max: 200, step: 4 } },
+    thickness: { control: { type: "range", min: 2, max: 24, step: 1 } },
+    appearance: {
+      control: "select",
+      options: [
+        "primary",
+        "success",
+        "warning",
+        "danger",
+        "neutral",
+        "ai-generative",
+      ],
+    },
+  },
+  args: { value: 64, appearance: "primary", size: 96, thickness: 8 },
+  render: (args) => (
+    <Box display="flex" flexDirection="column" gap="6" padding="4">
+      <Box display="flex" alignItems="center" gap="6">
+        <ProgressRing {...args} label="Store setup progress" />
+        <Box display="flex" flexDirection="column" gap="2" width="240px">
+          <Text fontSize="caption" color="neutral-textLow">
+            Same value on the shipped linear bar
+          </Text>
+          <ProgressBar
+            value={args.value}
+            appearance={
+              args.appearance === "ai-generative" ? "primary" : args.appearance
+            }
+          />
+        </Box>
+      </Box>
+
+      <Box display="flex" flexDirection="column" gap="2">
+        <Text fontSize="caption" color="neutral-textLow">
+          Smallest sizes — where the centre label stops being legible
+        </Text>
+        <Box display="flex" alignItems="center" gap="4">
+          {[24, 32, 40, 56, 72].map((size) => (
+            <ProgressRing
+              key={size}
+              value={args.value}
+              appearance={args.appearance}
+              size={size}
+              thickness={Math.max(2, Math.round(size / 12))}
+              label={`Progress at ${size} pixels`}
+            />
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  ),
+};
+
+const TASKS = [
+  "Add your first product",
+  "Set up a payment method",
+  "Choose a shipping option",
+  "Pick a domain",
+  "Customise your storefront",
+];
+
+/**
+ * Shareable experience. Ticking a task moves both indicators, so whoever tries
+ * it can judge which one they actually looked at.
+ */
+export const FullScreen: StoryObj<typeof ProgressRing> = {
+  name: "Full screen",
+  parameters: { layout: "fullscreen", controls: { disable: true } },
+  render: () => {
+    const [done, setDone] = useState<boolean[]>([
+      true,
+      true,
+      false,
+      false,
+      false,
+    ]);
+    const completed = done.filter(Boolean).length;
+    const value = (completed / TASKS.length) * 100;
+    const appearance = completed === TASKS.length ? "success" : "primary";
+
+    const toggle = (index: number) =>
+      setDone((prev) => prev.map((v, i) => (i === index ? !v : v)));
+
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        backgroundColor="neutral-background"
+        minHeight="100vh"
+        padding="6"
+      >
+        <Box
+          display="flex"
+          flexDirection="column"
+          gap="4"
+          width="100%"
+          maxWidth="520px"
+        >
+          <Title as="h2">Finish setting up your store</Title>
+
+          <Card>
+            <Card.Body>
+              <Box display="flex" alignItems="center" gap="6">
+                <ProgressRing
+                  value={value}
+                  appearance={appearance}
+                  size={104}
+                  label="Store setup progress"
+                >
+                  <Box display="flex" flexDirection="column">
+                    <Text fontSize="highlight" fontWeight="bold">
+                      {completed}/{TASKS.length}
+                    </Text>
+                    <Text fontSize="caption" color="neutral-textLow">
+                      done
+                    </Text>
+                  </Box>
+                </ProgressRing>
+
+                <Box display="flex" flexDirection="column" gap="2" flex="1">
+                  <Text>
+                    {completed === TASKS.length
+                      ? "Your store is ready to sell."
+                      : `${
+                          TASKS.length - completed
+                        } steps left before you can sell.`}
+                  </Text>
+                  <Text fontSize="caption" color="neutral-textLow">
+                    The same value, on the bar we ship today
+                  </Text>
+                  <ProgressBar value={value} appearance={appearance} />
+                </Box>
+              </Box>
+            </Card.Body>
+          </Card>
+
+          <Card>
+            <Card.Body>
+              <Box display="flex" flexDirection="column" gap="3">
+                {TASKS.map((task, index) => (
+                  <Checkbox
+                    key={task}
+                    name={`task-${index}`}
+                    label={task}
+                    checked={done[index]}
+                    onChange={() => toggle(index)}
+                  />
+                ))}
+              </Box>
+            </Card.Body>
+          </Card>
+        </Box>
+      </Box>
+    );
+  },
+};


### PR DESCRIPTION
> [!IMPORTANT]
> This is a disposable Nimbus prototype. Keep this pull request in draft and
> close it without merging after preserving the outcome.

## Intention

**What should someone be able to do?**

See how far along a task they are, with the value at the centre of the indicator, in places where the linear bar either does not fit or does not stand out — a summary card, a compact header, a tile.

**Who would use it, and in which situation?**

A merchant finishing the setup of their store, in the admin panel, glancing at the panel to decide whether anything is still missing before they can sell.

**What question should this prototype help answer?**

Does the ring communicate progress better than the shipped linear bar when there is a value at its centre and little horizontal space — and at what diameter does the centre label stop being legible?

**Owner or contact:** @harrytiendanube

## What to try

Open the **Full screen** link on a phone and on a laptop, and tick the setup tasks off one at a time.

Both indicators move together on purpose: the ring in the card header and the linear bar we ship today, on the same value. The thing to notice is **which one you actually looked at** to answer "how much is left?", and whether the `2/5 done` at the centre pulled your eye or just added noise.

Then open the **Playground** link and drag `value` and `size`. The row of small rings at the bottom is there to find the diameter where the label breaks down.

The API deliberately mirrors `@nimbus-ds/progress-bar` — same `value`, same six `appearance` values. The open question is the shape, not a new API.

## Simulated parts and limitations

- **`ai-generative` is not faithful.** `ProgressBar` paints that appearance with a gradient and there is no single `interactive` token for it, so the ring falls back to the `primary` token. Every other colour is a real theme token via `--nimbus-colors-*`.
- **The centre label size is an invented formula** (`size / 5`, floor 11px), not a typography token. This is the direct cause of the legibility problem below.
- **Inline styles and a hand-written SVG**, not vanilla-extract with `varsThemeBase`. A real component would not be built this way.
- **The five setup tasks and their initial state are mock data.** No backend, no routing, no persistence, no authentication. Ticking a box only moves React state.
- **No accessibility review.** The ring carries `role="progressbar"` with `aria-valuenow/valuemin/valuemax` and an `aria-label`, but nothing was validated with a screen reader.
- Static page: the interaction is limited to this one screen, not an end-to-end product flow.

## Observations and evidence

Verified locally on `a9210c2`, rendered with Chromium at 1280×760, 1280×900 and 390×800:

- **Below roughly 40px the centre label overflows the ring.** At 24px and 32px the `64%` text crosses the stroke and becomes unreadable. So either the ring has a minimum usable diameter, or below it the label has to be dropped and the ring becomes a bare arc — which is a different component with a different purpose.
- The `2/5 done` framing at the centre reads more concretely than a percentage for a countable list of tasks. Worth testing whether that holds when the total is not small.
- On a 390px viewport the ring and the text next to it still fit side by side in the card without wrapping.
- No participant other than the author has tried it yet. **This section is incomplete until someone else does** — the answer to the question above is not yet evidence.

Screenshots to be attached before closing, so the result survives the preview.

## Outcome

- [x] Still exploring
- [ ] Discard
- [ ] Start a materially different exploration
- [ ] Formal handoff
- [ ] Expired after 30 days without activity

**Why this outcome?**

The prototype renders and is usable, but the learning question is unanswered: only the author has looked at it. It stays open until at least one person who was not involved in building it tries the full-screen view.

**Follow-up link, when applicable:** n/a

## Closure

- [ ] The outcome remains understandable after the preview disappears.
- [x] Mocked, hardcoded, and simulated behavior is documented.
- [x] No secrets, personal data, customer data, or confidential information was used.
- [x] This pull request will be closed without merging.

## Note on the base branch

This targets `onb-1176/prototyping-playground` ([#525](https://github.com/TiendaNube/nimbus-design-system/pull/525)), not `master`, because the Playground enabler is not merged yet — the directory, the exclusions and the preview resolver only exist there. So the diff is the two prototype files alone.

That also makes this the first real exercise of two behaviours #525 could not test on its own branch: the `checklist-comment` skip and the `build:packages` skip, both gated on a `prototype/*` head ref.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGNetd9Jz2kgjJLAj5ppdV)_