### PR TITLE
chore(workflows): colapsar la cadena de release sin PAT (Fase 3)

### DIFF
--- a/.github/workflows/create-github-tag.yml
+++ b/.github/workflows/create-github-tag.yml
@@ -19,7 +19,7 @@ jobs:
         id: calver
         with:
           date_format: "%Y.%m.%d"
-          release: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          release: false
           release_branch: master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -29,14 +29,6 @@ jobs:
         with:
           tag: ${{ steps.calver.outputs.release }}
 
-  # NOTE for reviewers: this used to be dispatched via curl against a
-  # hardcoded workflow ID, always as a standalone `workflow_dispatch` run —
-  # so `github.event_name` above was never 'push', and the `release` input
-  # to actions-calver always evaluated false. Chained like this from
-  # publish.yml (which triggers on push to master), `release` now evaluates
-  # true for the first time. Flagging this explicitly: it's a behavior
-  # change, not just a mechanism change, and is worth a second look from
-  # whoever knows this release pipeline best before merging.
   create-github-release:
     needs: [create-github-tag]
     permissions:

--- a/.github/workflows/create-github-tag.yml
+++ b/.github/workflows/create-github-tag.yml
@@ -1,6 +1,11 @@
 name: "create-github-tag"
 
-on: workflow_dispatch
+# Runs on manual dispatch inside nimbus-design-system, and is also callable
+# as a reusable workflow — publish.yml chains into it directly instead of
+# dispatching it by workflow ID over the API with a PAT.
+on:
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
   create-github-tag:
@@ -24,13 +29,17 @@ jobs:
         with:
           tag: ${{ steps.calver.outputs.release }}
 
-  trigger-action-create-github-release:
+  # NOTE for reviewers: this used to be dispatched via curl against a
+  # hardcoded workflow ID, always as a standalone `workflow_dispatch` run —
+  # so `github.event_name` above was never 'push', and the `release` input
+  # to actions-calver always evaluated false. Chained like this from
+  # publish.yml (which triggers on push to master), `release` now evaluates
+  # true for the first time. Flagging this explicitly: it's a behavior
+  # change, not just a mechanism change, and is worth a second look from
+  # whoever knows this release pipeline best before merging.
+  create-github-release:
     needs: [create-github-tag]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger github action create github release
-        run: |
-          curl --request POST \
-          --url 'https://api.github.com/repos/tiendanube/nimbus-design-system/actions/workflows/58856078/dispatches' \
-          --header 'Authorization: token ${{ secrets.PAT_CHANGE_BRANCH_PROTECTION_RULES_FROM_JUNIOR_CONQUISTA }}' \
-          --data '{"ref":"master"}'
+    permissions:
+      contents: write
+      discussions: write
+    uses: ./.github/workflows/create-github-relase.yml

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -1,10 +1,18 @@
 name: "generate-documentation"
 
-on: workflow_dispatch
+# Runs on manual dispatch inside nimbus-design-system, and is also callable
+# as a reusable workflow — publish.yml chains into it directly instead of
+# dispatching it by workflow ID over the API with a PAT.
+on:
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
   generate-documents:
     runs-on: ubuntu-latest
+    # Needed for git-auto-commit-action to push the generated docs.
+    permissions:
+      contents: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,49 +76,25 @@ jobs:
           base: master
           
 
-  trigger-action-create-github-tag:
-    runs-on: ubuntu-latest
-    needs: publish-packages-npm
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+  create-tag-and-release:
+    needs: [publish-packages-npm]
+    permissions:
+      contents: write
+      discussions: write
+    uses: ./.github/workflows/create-github-tag.yml
 
-      - name: Trigger github action create github tag
-        run: |
-          curl --request POST \
-          --url 'https://api.github.com/repos/tiendanube/nimbus-design-system/actions/workflows/58856079/dispatches' \
-          --header 'Authorization: token ${{ secrets.PAT_CHANGE_BRANCH_PROTECTION_RULES_FROM_USER_NIMBUS }}' \
-          --data '{"ref":"master"}'
+  send-slack-notification:
+    needs: [publish-packages-npm, create-tag-and-release]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/send-slack-notification.yml
+    secrets:
+      SLACK_WEBHOOK_URL_NIMBUS_UPDATES: ${{ secrets.SLACK_WEBHOOK_URL_NIMBUS_UPDATES }}
+      SLACK_WEBHOOK_URL_DEPLOYING: ${{ secrets.SLACK_WEBHOOK_URL_DEPLOYING }}
+      SLACK_WEBHOOK_URL_TECH_PRODUCT_UPDATES: ${{ secrets.SLACK_WEBHOOK_URL_TECH_PRODUCT_UPDATES }}
 
-  trigger-action-send-slack-notifications:
-    needs: [publish-packages-npm, trigger-action-create-github-tag]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Trigger github action send slack notifications
-        run: |
-          curl --request POST \
-          --url 'https://api.github.com/repos/tiendanube/nimbus-design-system/actions/workflows/58847410/dispatches' \
-          --header 'Authorization: token ${{ secrets.PAT_CHANGE_BRANCH_PROTECTION_RULES_FROM_USER_NIMBUS }}' \
-          --data '{"ref":"master"}'
-
-  trigger-action-update-generate-documentation:
-    needs:
-      [
-        publish-packages-npm,
-        trigger-action-create-github-tag,
-        trigger-action-send-slack-notifications,
-      ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Trigger github action update documentation
-        run: |
-          curl --request POST \
-          --url 'https://api.github.com/repos/tiendanube/nimbus-design-system/actions/workflows/51785513/dispatches' \
-          --header 'Authorization: token ${{ secrets.PAT_CHANGE_BRANCH_PROTECTION_RULES_FROM_USER_NIMBUS }}' \
-          --data '{"ref":"master"}'
+  generate-documentation:
+    needs: [publish-packages-npm, create-tag-and-release, send-slack-notification]
+    permissions:
+      contents: write
+    uses: ./.github/workflows/generate-documentation.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,3 +98,8 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/generate-documentation.yml
+    # generate-documentation.yml doesn't declare a workflow_call secrets
+    # schema (its PAT and Turbo credentials are used directly in run: steps,
+    # not passed to a nested `uses:`), so explicit per-secret passthrough
+    # isn't an option here — inherit is the only way for them to arrive.
+    secrets: inherit

--- a/.yarn/versions/68b78697.yml
+++ b/.yarn/versions/68b78697.yml
@@ -1,0 +1,2 @@
+declined:
+  - nimbus-design-system


### PR DESCRIPTION
## Qué cambia

Fase 3 del plan de unificación. Apunta contra la rama de #519 a propósito: cuando #519 mergee a master, este PR queda apuntando a master automáticamente.

`publish.yml` disparaba 3 workflows (`create-github-tag`, `send-slack-notification`, `generate-documentation`) con `curl` + un PAT contra IDs de workflow hardcodeados. `create-github-tag.yml` hacía lo mismo para disparar `create-github-relase`. Ahora los 4 se encadenan con `needs:`/`uses:` dentro del mismo run — sin PAT, usando el `GITHUB_TOKEN` automático más los permisos que ya declaraba cada job.

## ⚠️ Para el reviewer — cambio de comportamiento, no solo de mecanismo

`create-github-tag.yml` calcula `release: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}` para el input de `actions-calver`. Hasta ahora ese workflow **solo** se disparaba vía `workflow_dispatch` (el curl), así que `github.event_name` nunca era `push` — esa condición siempre evaluó `false`. Al encadenarlo desde `publish.yml` (que corre en `push` a `master`), la condición evalúa `true` por primera vez. No tengo forma de confirmar sin dudas si esto cambia lo que efectivamente se taguea/publica — pido que alguien que conozca bien este pipeline lo revise antes de mergear.

## Cómo se probó

- `actionlint` + `yamllint` limpios (solo warnings preexistentes de versiones de actions).
- `act` dry-run valida la cadena anidada de 3 niveles (`publish.yml` → `create-github-tag.yml` → `create-github-relase.yml`) — resuelve y corre bien.
- `yarn lint`, `yarn types:check`, `yarn test` vía el pre-push hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated publishing workflows with reusable, manually triggerable processes.
  * Added clearer job sequencing and permissions for release tagging, documentation generation, and notifications.
  * Enabled generated documentation to be committed automatically.
  * Improved release handling for calendar-based versioning on master branch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Reemplaza a #521 (cerrado automáticamente sin mergear al borrarse la rama base chore/reusable-workflows-phase1). Mismo código, mismos commits.
