### PR TITLE
chore(workflows): alinear inconsistencias reales con nimbus-patterns (Fase 4)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
 # Add the following users as reviewers on new pull requests
 
 * @TiendaNube/access-tech-nimbus
+
+# Shared with nimbus-patterns as the reusable-workflow source (nimbus-design-system#519)
+.github/workflows/ @harrytiendanube @EzeNube
+.github/actions/ @harrytiendanube @EzeNube

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -28,3 +28,5 @@ jobs:
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --all-projects

--- a/.yarn/versions/f6ae8f15.yml
+++ b/.yarn/versions/f6ae8f15.yml
@@ -1,0 +1,2 @@
+declined:
+  - nimbus-design-system


### PR DESCRIPTION
## Qué cambia

Fase 4 del plan de unificación. Apunta contra la rama de #519 a propósito: cuando #519 mergee a master, este PR queda apuntando a master automáticamente.

A diferencia de las fases anteriores, estos workflows (`pull-request`, `publish-codecov`, `sonar`, `snyk`, `publish-storybook`, `cleanup-storybook-preview`) tienen orden de pasos distinto entre repos (ej. build antes o después de lint/test) — unificarlos en un solo reusable implicaría reordenar pasos, así que **no se fusionan**. Solo se corrige la única inconsistencia real de este lado:

- `snyk.yml`: faltaba `args: --all-projects` (nimbus-patterns ya lo tenía) — sin esto solo se escaneaba el proyecto raíz, no todos los workspaces del monorepo.

El resto de las correcciones de esta fase están del lado de `nimbus-patterns` (ver PR hermano).

## Cómo se probó

`actionlint` + `yamllint` limpios (solo warnings preexistentes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable workflows for Storybook previews, release creation, checklist comments, and Slack notifications.
  * Storybook previews now build, deploy, and update pull request comments with a preview link.
  * Expanded security scanning to include all detected projects.

* **Chores**
  * Added review ownership rules for workflow and action configuration changes.
  * Added explicit permissions and validation for improved workflow security and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Reemplaza a #522 (cerrado automáticamente sin mergear al borrarse la rama base chore/reusable-workflows-phase1). Mismo código, mismos commits.
