### PR TITLE
fix: enable preferDeferredVersions in yarn config

### DIFF
--- a/.yarn/versions/8e6f6e22.yml
+++ b/.yarn/versions/8e6f6e22.yml
@@ -1,0 +1,2 @@
+declined:
+  - nimbus-design-system

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,6 +9,8 @@ changesetIgnorePatterns:
 
 nodeLinker: node-modules
 
+preferDeferredVersions: true
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
     spec: "@yarnpkg/plugin-workspace-tools"


### PR DESCRIPTION
## Problem

Both this repo and `nimbus-patterns` use Yarn Berry with the official `@yarnpkg/plugin-version` plugin, but neither sets `preferDeferredVersions` in `.yarnrc.yml` (the default is `false`).

Without that flag, `yarn version patch` correctly writes the `.yarn/versions/<hash>.yml` file with its `releases:` entry, but since the command isn't in deferred mode it automatically triggers `yarn version apply` right after. That command rereads the same `.yml`, treats the entry as "already applied", removes it, and leaves the version file serialized empty (0 bytes).

This is what broke `yarn version check` on the e2e release pipeline test PR (#540 in this repo, #194 in `nimbus-patterns`), where it had to be corrected by hand as a workaround.

## Fix

Set `preferDeferredVersions: true` in `.yarnrc.yml` so `yarn version <strategy>` only records the pending release strategy in `.yarn/versions/*.yml`, leaving `yarn version apply` to the release pipeline instead of running it implicitly on every `yarn version` invocation.

## Note

This PR itself only touches `.yarnrc.yml`, a repo-level config file (not published package source), so a `declined` release-strategy entry was added under `.yarn/versions/` just to satisfy `yarn version check`.

Refs ONB-1164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version handling to defer version resolution when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->