### PR TITLE
fix: open a PR for generated docs instead of pushing directly to master

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -10,9 +10,10 @@ on:
 jobs:
   generate-documents:
     runs-on: ubuntu-latest
-    # Needed for git-auto-commit-action to push the generated docs.
+    # Needed for create-pull-request to push the docs branch and open the PR.
     permissions:
       contents: write
+      pull-requests: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -31,22 +32,16 @@ jobs:
       - name: Generate documents
         run: yarn build:docs
 
-      - name: Branch protection OFF
-        run: |
-          curl --request PUT \
-          --url 'https://api.github.com/repos/tiendanube/nimbus-design-system/branches/master/protection' \
-          --header 'Authorization: token ${{ secrets.PAT_CHANGE_BRANCH_PROTECTION_RULES_FROM_USER_NIMBUS }}' \
-          --data '{"enforce_admins":false,"required_pull_request_reviews":null,"required_status_checks":null,"required_conversation_resolution":false,"restrictions":null,"required_linear_history":false}'
-
-      - name: Commit documents
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Create documentation PR
+        uses: peter-evans/create-pull-request@v7
         with:
-          commit_message: "chore: updated documentation for components and subcomponents"
-
-      - name: Branch protection ON
-        run: |
-          curl --request PUT \
-          --url 'https://api.github.com/repos/tiendanube/nimbus-design-system/branches/master/protection' \
-          --header 'Authorization: token ${{ secrets.PAT_CHANGE_BRANCH_PROTECTION_RULES_FROM_USER_NIMBUS }}' \
-          --header 'Accept: application/vnd.github.luke-cage-preview+json' \
-          --data '{"enforce_admins":true,"required_pull_request_reviews":{"dismiss_stale_reviews":true,"require_code_owner_reviews":true,"required_approving_review_count":1},"required_conversation_resolution":true,"required_status_checks":null,"restrictions":null,"required_linear_history":true}'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: updated documentation for components and subcomponents [skip ci]"
+          title: "chore: update component documentation"
+          body: |
+            Automated documentation update — regenerates component and subcomponent docs.
+          add-paths: |
+            **/*.docs.json
+          branch: docs/update-${{ github.run_id }}
+          base: master
+          delete-branch: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,9 +97,10 @@ jobs:
     needs: [publish-packages-npm, create-tag-and-release, send-slack-notification]
     permissions:
       contents: write
+      pull-requests: write
     uses: ./.github/workflows/generate-documentation.yml
     # generate-documentation.yml doesn't declare a workflow_call secrets
-    # schema (its PAT and Turbo credentials are used directly in run: steps,
-    # not passed to a nested `uses:`), so explicit per-secret passthrough
-    # isn't an option here — inherit is the only way for them to arrive.
+    # schema (its Turbo credentials are used directly in run: steps, not
+    # passed to a nested `uses:`), so explicit per-secret passthrough isn't
+    # an option here — inherit is the only way for them to arrive.
     secrets: inherit

--- a/.yarn/versions/b63739a1.yml
+++ b/.yarn/versions/b63739a1.yml
@@ -1,0 +1,2 @@
+declined:
+  - nimbus-design-system


### PR DESCRIPTION
## Summary

`generate-documentation.yml` toggled branch protection off via a raw `curl` to the GitHub API, pushed the regenerated docs with `stefanzweifel/git-auto-commit-action`, then re-enabled protection. That toggle is racy — if it doesn't complete cleanly the push is rejected with `GH013` and the docs update is lost, even though the package published fine.

- Replace the branch-protection toggle + direct push with `peter-evans/create-pull-request@v7`, the same pattern `publish.yml` already uses for release commits.
- Add `pull-requests: write` to the job's permissions (and to the caller job in `publish.yml`) since `contents: write` alone is no longer enough.
- Declined a release for this workspace via `yarn version decline --deferred` — workflow-only change, doesn't affect the published package.

## Test plan

- [x] `yarn build:tokens && yarn build:icons` then `yarn lint` and `yarn test` (117 suites / 1015 tests) pass on this branch.
- [ ] Merge and confirm the next scheduled/manual `generate-documentation` run opens a PR instead of failing with `GH013`.

Refs ONB-1231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Generated documentation updates are now published through pull requests for review before merging.
  - Documentation generation no longer commits changes directly to the main branch.

- **Chores**
  - Updated automation permissions and workflow handling to support the new documentation update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->