### PR TITLE
ci(workflows): auto-retag workflows-v1 on every reusable workflow change

### DIFF
--- a/.github/workflows/retag-reusable-workflows.yml
+++ b/.github/workflows/retag-reusable-workflows.yml
@@ -1,0 +1,44 @@
+name: "retag-reusable-workflows"
+
+# Moves the `workflows-v1` tag to master's new HEAD whenever a push touches one
+# of the reusable workflows other Nimbus repos call via `@workflows-v1`. Keeps
+# that tag floating like `actions/checkout@v4` does: consumers get the change
+# on their next run, with no PR to bump a pinned ref. The tradeoff is real — a
+# broken reusable workflow reaches every consumer immediately, with no review
+# gate on their side — so anyone editing these files should treat master as the
+# release, not a staging step before one.
+#
+# Add a file here whenever a new reusable workflow is meant to be consumed
+# cross-repo under this same tag.
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/checklist-comment.yml"
+      - ".github/workflows/create-github-relase.yml"
+      - ".github/workflows/preview-storybook-deploy.yml"
+      - ".github/workflows/send-slack-notification.yml"
+      - ".github/workflows/retag-reusable-workflows.yml"
+
+# Pushes to master land one at a time in practice, but a queued second run
+# retagging behind a first one would move workflows-v1 backwards to a commit
+# that is no longer HEAD.
+concurrency:
+  group: retag-reusable-workflows
+  cancel-in-progress: false
+
+jobs:
+  retag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Move workflows-v1 to this commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f workflows-v1
+          git push origin refs/tags/workflows-v1 --force

--- a/.yarn/versions/68ba8264.yml
+++ b/.yarn/versions/68ba8264.yml
@@ -1,0 +1,2 @@
+declined:
+  - nimbus-design-system


### PR DESCRIPTION
## Por qué

`workflows-v1` es el tag que nimbus-patterns usa para consumir los workflows reusables de este repo (`checklist-comment`, `create-github-relase`, `preview-storybook-deploy`, `send-slack-notification`). Desde que se creó en la Fase 3/4 de ONB-1164 (#534/#535) nadie lo movió — quedó fijo en ese commit del 1/9, así que patterns está consumiendo una versión vieja de esos workflows sin que nadie lo haya decidido explícitamente. Justo el problema que bloqueaba [#518](https://github.com/TiendaNube/nimbus-design-system/pull/518): sus cambios al reusable `preview-storybook-deploy.yml` no llegan a nimbus-patterns hasta que alguien mueva el tag a mano.

## Qué cambia

Nuevo workflow `retag-reusable-workflows.yml`: en cada push a `master` que toque alguno de los 4 workflows reusables (o a sí mismo), fuerza `workflows-v1` al nuevo HEAD. Mismo patrón que usan las actions de terceros con tags de versión mayor flotantes (`actions/checkout@v4`).

**Trade-off explícito, no un bug**: esto vuelve `workflows-v1` un tag que se mueve solo. Un cambio con bug en alguno de esos 4 workflows llega a la CI de nimbus-patterns en el próximo push, sin ningún gate de revisión del lado de patterns. A partir de este PR, un cambio a esos archivos en master **es** el release, no un paso previo a uno.

## Type
- [x] Tech debt 👩‍💻

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow tagging for designated reusable workflows.
  * The `workflows-v1` tag now updates automatically when relevant changes are pushed to the master branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->